### PR TITLE
Add missing `this`

### DIFF
--- a/packages/model-fragments/lib/fragments/attributes.js
+++ b/packages/model-fragments/lib/fragments/attributes.js
@@ -35,7 +35,7 @@ function hasOneFragment (type, options) {
     }
 
     if (arguments.length > 1) {
-      Ember.assert("You can only assign a '" + type + "' fragment to this property", value instanceof store.modelFor(type));
+      Ember.assert("You can only assign a '" + type + "' fragment to this property", value instanceof this.store.modelFor(type));
 
       fragment = value;
 


### PR DESCRIPTION
`store` is undefined in this context, making the assertion blow up.

Reproduction case:

``` js
var User = DS.ModelFragment.extend({name: DS.attr('string')});
var Comment = DS.Model.extend({
  user: DS.hasOneFragment('user')
});

// later, somewhere with a store:
var user = this.store.createFragment('user', {name: 'test'});

// this errors out with `store is undefined`
var comment = this.store.createRecord('comment', {user: user});
```
