### PR TITLE
Fix bower.json dependencies.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,12 +18,11 @@
     "testem.json"
   ],
   "dependencies": {
-    "ember": "^1.4.0"
+    "ember": "^1.4.0",
+    "ember-data": "1.0.0-beta.7"
   },
   "devDependencies": {
     "jquery": "~2.0.0",
-    "handlebars": "~1.3.0",
-    "ember": "~1.4.0",
-    "ember-data": "1.0.0-beta.7"
+    "ember": "~1.4.0"
   }
 }


### PR DESCRIPTION
Ember-data is a dependency at runtime, not just a devDependency.

I noticed this because my build tool, [Brunch](http://brunch.io), builds a dependency graph for concatenating Bower components in the right order. Ember Data needs to be listed as a dependency for it to be included before EmberData.model-fragments.
