### PR TITLE
ember data beta-12 compatibility

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,10 +19,14 @@
   ],
   "dependencies": {
     "ember": "^1.4.0",
-    "ember-data": "1.0.0-beta.7"
+    "ember-data": "1.0.0-beta.12"
   },
   "devDependencies": {
     "jquery": "~2.0.0",
     "ember": "~1.4.0"
+  },
+  "resolutions": {
+    "ember": ">= 1.7.0",
+    "handlebars": ">= 2.0.0 < 3.0.0"
   }
 }

--- a/packages/model-fragments/lib/core-model.js
+++ b/packages/model-fragments/lib/core-model.js
@@ -13,6 +13,7 @@ Model.proto();
 var protoProps = [
   '_setup',
   '_unhandledEvent',
+  '_notifyProperties',
   'send',
   'transitionTo',
   'data',

--- a/packages/model-fragments/lib/fragments/attributes.js
+++ b/packages/model-fragments/lib/fragments/attributes.js
@@ -92,7 +92,7 @@ function hasOneFragment(declaredType, options) {
     }
 
     return this._fragments[key] = fragment;
-  }).property('data').meta(meta);
+  }).property('isDirty').meta(meta);
 }
 
 /**
@@ -194,7 +194,7 @@ function hasManyFragments(declaredType, options) {
     }
 
     return this._fragments[key] = fragments;
-  }).property('data').meta(meta);
+  }).property('isDirty').meta(meta);
 }
 
 // Like `DS.belongsTo`, when used within a model fragment is a reference

--- a/packages/model-fragments/lib/fragments/model.js
+++ b/packages/model-fragments/lib/fragments/model.js
@@ -114,7 +114,7 @@ var ModelFragment = CoreModel.extend(Ember.Comparable, Ember.Copyable, {
     this.send('pushedData');
 
     // Notify attribute properties/observers of internal change to `_data`
-    this.notifyPropertyChange('data');
+    this._notifyProperties(Em.keys(this._data));
   },
 
   /**
@@ -144,7 +144,7 @@ var ModelFragment = CoreModel.extend(Ember.Comparable, Ember.Copyable, {
     this.send('rolledBack');
 
     // Notify attribute properties/observers of internal change to `_data`
-    this.notifyPropertyChange('data');
+    this._notifyProperties(Em.keys(this._data));
   },
 
   /**


### PR DESCRIPTION
Fix for #31 

Unfortunately this change does break compatibility with ember data before beta 12. 
I could copy the [_notifyProperties function](https://github.com/emberjs/data/blob/d5f19518cb7b7e62b650ce6ce2329f9d0f1557e1/packages/ember-data/lib/system/model/model.js#L765) from ember data and that might restore compatibility.

[Updated JSBin](http://emberjs.jsbin.com/sayudujalu/2/edit?html,css,js,output)
