### PR TITLE
fix(hasDirtyAttributes): fix hasDirtyAttributes when resetting a property

### DIFF
--- a/addon/record-data.js
+++ b/addon/record-data.js
@@ -302,9 +302,11 @@ export default class FragmentRecordData extends RecordData {
   }
 
   hasChangedAttributes() {
-    return (
-      this.__attributes !== null && Object.keys(this.__attributes).length > 0
-    );
+    return super.hasChangedAttributes() ||
+      this.fragmentNames.some(fragmentName => {
+        const fragment = this.getFragmentWithoutCreating(fragmentName);
+        return fragment && fragment.hasDirtyAttributes;
+      });
   }
 
   resetRecord() {

--- a/tests/integration/dependent_state_test.js
+++ b/tests/integration/dependent_state_test.js
@@ -1019,4 +1019,40 @@ module('integration - Dependent State', function(hooks) {
       });
     });
   });
+
+  test('updating a fragment and a property then resetting the property', function(assert) {
+    run(() => {
+      pushPerson(1);
+
+      return store.find('person', 1).then(person => {
+        assert.ok(
+          !person.get('hasDirtyAttributes'),
+          'person record is not dirty'
+        );
+
+        person.name.set('first', 'Another firstname');
+        assert.ok(
+          person.get('hasDirtyAttributes'),
+          'person record is dirty'
+        );
+
+        const oldTitle = person.title;
+        person.set('title', 'New title');
+        assert.ok(
+          person.get('hasDirtyAttributes'),
+          'person record is dirty'
+        );
+
+        person.set('title', oldTitle);
+        assert.ok(
+          person.name.get('hasDirtyAttributes'),
+          'fragment name is dirty'
+        );
+        assert.ok(
+          person.get('hasDirtyAttributes'),
+          'person record is dirty'
+        );
+      });
+    });
+  });
 });


### PR DESCRIPTION
# Steps to reproduce the issue
- Changing a fragment
- Then changing a property
- And finally resetting the property to its old value

# Expected behaviour
`hasDirtyAttributes` should be `true`

# Current behaviour
`hasDirtyAttributes` is `false`