### PR TITLE
Make sure we can update fragments/fragment arrays after they are initially set to null

### DIFF
--- a/addon/record-data.js
+++ b/addon/record-data.js
@@ -27,18 +27,21 @@ export default class FragmentRecordData extends RecordData {
       super(identifier.type, identifier.id, identifier.clientId, store);
     }
 
+    // @patocallaghan - We need to keep a copy of the record so we can recreate the fragment/fragmentArray.
+    this._record = null;
     this.fragmentData = Object.create(null);
     this.serverFragments = Object.create(null);
     this.inFlightFragments = Object.create(null);
 
     this.fragments = Object.create(null);
-    this.fragmentNames = [];
+    // @patocallaghan - We need to keep the fragment definitions for later on in case we need recreate the fragment or fragmentArray
+    this.fragmentDefs = Object.create(null);
     let defs = store.attributesDefinitionFor(identifier.type, identifier.id, identifier.lid);
 
     Object.keys(defs).forEach(key => {
       let options = defs[key];
       if (options.isFragment) {
-        this.fragmentNames.push(key);
+        this.fragmentDefs[key] = defs[key];
       }
     });
     fragmentRecordDatas.set(identifier, this);
@@ -54,6 +57,8 @@ export default class FragmentRecordData extends RecordData {
   }
 
   setupFragment(key, options, declaredModelName, record) {
+    // @patocallaghan -  This is extremely janky way of making sure we always have a copy of the record saved. There must be a better way of doing this?
+    this._record = record;
     let data = this.getFragmentDataWithDefault(key, options, 'object');
     let fragment = this.fragments[key];
 
@@ -79,6 +84,7 @@ export default class FragmentRecordData extends RecordData {
   }
 
   getFragment(key, options, declaredModelName, record) {
+    this._record = record;
     let fragment = this.getFragmentWithoutCreating(key);
     if (fragment === undefined) {
       return this.setupFragment(key, options, declaredModelName, record);
@@ -88,6 +94,7 @@ export default class FragmentRecordData extends RecordData {
   }
 
   setFragmentArrayValue(key, fragments, value, record, declaredModelName, options, isFragmentArray) {
+    this._record = record;
     if (isArray(value)) {
       if (!fragments) {
         if (isFragmentArray) {
@@ -126,6 +133,7 @@ export default class FragmentRecordData extends RecordData {
 
     // Model Fragments are hard tied to DS.Model, and all DS.Models have the store on them.
     // We need access to the store because EDMF uses the store for `createRecord`
+    this._record = record;
     let store = record.store;
     assert(
       `You can only assign \`null\`, an object literal or a '${declaredModelName}' fragment instance to this property`,
@@ -170,6 +178,7 @@ export default class FragmentRecordData extends RecordData {
   }
 
   getFragmentArray(key, options, declaredModelName, record, isFragmentArray) {
+    this._record = record;
     let data = this.getFragmentDataWithDefault(key, options, 'array');
     let fragmentArray = this.getFragmentWithoutCreating(key);
 
@@ -185,6 +194,7 @@ export default class FragmentRecordData extends RecordData {
   }
 
   setupFragmentArray(key, record, data, declaredModelName, options, isFragmentArray) {
+    this._record = record;
     let fragmentArray;
     if  (data !== null) {
       if (isFragmentArray) {
@@ -223,7 +233,7 @@ export default class FragmentRecordData extends RecordData {
   setupFragmentData(data, calculateChange) {
     let keys = [];
     if (data.attributes) {
-      this.fragmentNames.forEach(name => {
+      Object.keys(this.fragmentDefs).forEach(name => {
         if (calculateChange && this.getFragmentWithoutCreating(name) !== undefined) {
           keys.push(name);
         }
@@ -261,7 +271,7 @@ export default class FragmentRecordData extends RecordData {
 
     let ourAttributes = {};
     if (data.attributes) {
-      this.fragmentNames.forEach(name => {
+      Object.keys(this.fragmentDefs).forEach(name => {
         if (name in data.attributes) {
           ourAttributes[name] = data.attributes[name];
           delete data.attributes[name];
@@ -307,7 +317,7 @@ export default class FragmentRecordData extends RecordData {
 
   hasChangedAttributes() {
     return super.hasChangedAttributes() ||
-      this.fragmentNames.some(fragmentName => {
+      Object.keys(this.fragmentDefs).some(fragmentName => {
         const fragment = this.getFragmentWithoutCreating(fragmentName);
         return fragment && fragment.hasDirtyAttributes;
       });
@@ -359,7 +369,7 @@ export default class FragmentRecordData extends RecordData {
     // for more details
 
     let ourChanges = super.changedAttributes();
-    for (let key of this.fragmentNames) {
+    for (let key of Object.keys(this.fragmentDefs)) {
       // either the whole fragment was replaced, or a property on the fragment was replaced
       // this is the case where we replaced the whole framgent
       let newFragment;
@@ -405,7 +415,7 @@ export default class FragmentRecordData extends RecordData {
       keys.push(key);
       delete this.fragments[key];
     }
-    this.fragmentNames.forEach((key) => {
+    Object.keys(this.fragmentDefs).forEach((key) => {
       let fragment = this.getFragmentWithoutCreating(key);
       if (fragment) {
         fragment.rollbackAttributes();
@@ -427,12 +437,24 @@ export default class FragmentRecordData extends RecordData {
       delete this.inFlightFragments[key];
       this.serverFragments[key] = fragment;
     }
-    this.fragmentNames.forEach(key => {
+    Object.keys(this.fragmentDefs).forEach(key => {
       fragment = this.serverFragments[key];
+      // @patocallaghan - So basically if the existing fragment/fragmentArray is null but it is part of the response we need to recreate the fragment/fragment array and re-add it to the record.
+      // Unfortunately we have no access to the `record` (is there a way to get it from `RecordData`?) in this codepath hence why we need to do the `this._record` hack.
+      if (!fragment && attributes[key] && this._record) {
+        let def = this.fragmentDefs[key];
+        let declaredModelName = def.type.split('$')[1];
+        if (def.type.includes('-array')) {
+          fragment = this.setupFragmentArray(key, this._record, attributes[key], declaredModelName, def.options, def.type.includes('fragment-array'));
+        } else {
+          fragment = createFragment(this._record.store, def.type.split('$')[1], this._record, key, def.options, attributes[key]);
+        }
+        // @patocallaghan - Not sure of the repercussions of just re-assigning the new fragment here. Should it be done a better way?
+        this._record[key] = fragment;
+      }
       if (fragment) {
         fragment._didCommit(attributes[key]);
       }
-      // this is here so that the super call does not process this key
       delete attributes[key];
     });
     return super.didCommit(data);

--- a/tests/dummy/app/models/name.js
+++ b/tests/dummy/app/models/name.js
@@ -4,6 +4,7 @@ import MF from 'ember-data-model-fragments';
 export default MF.Fragment.extend({
   first: attr('string'),
   last: attr('string'),
+  prefixes: MF.fragmentArray('prefix'),
   person: MF.fragmentOwner(),
 
   ready() {

--- a/tests/dummy/app/models/prefix.js
+++ b/tests/dummy/app/models/prefix.js
@@ -1,0 +1,7 @@
+import { attr } from '@ember-data/model';
+import MF from 'ember-data-model-fragments';
+
+export default MF.Fragment.extend({
+  name: attr('string')
+});
+

--- a/tests/unit/fragment_array_test.js
+++ b/tests/unit/fragment_array_test.js
@@ -323,11 +323,13 @@ module('unit - `MF.fragmentArray`', function(hooks) {
       assert.deepEqual(person.names.toArray().map((f) => f.serialize()), [
         {
           'first': 'Catelyn',
-          'last': 'Tully'
+          'last': 'Tully',
+          prefixes: []
         },
         {
           'first': 'Catelyn',
-          'last': 'Stark'
+          'last': 'Stark',
+          prefixes: []
         }
       ]);
 

--- a/tests/unit/serialize_test.js
+++ b/tests/unit/serialize_test.js
@@ -120,15 +120,18 @@ module('unit - Serialization', function(hooks) {
     let names = [
       {
         first: 'Rhaegar',
-        last: 'Targaryen'
+        last: 'Targaryen',
+        prefixes: []
       },
       {
         first: 'Viserys',
-        last: 'Targaryen'
+        last: 'Targaryen',
+        prefixes: []
       },
       {
         first: 'Daenerys',
-        last: 'Targaryen'
+        last: 'Targaryen',
+        prefixes: []
       }
     ];
 


### PR DESCRIPTION
This is a failing test which mimics the bug in https://github.com/lytics/ember-data-model-fragments/issues/375. This worked before the 5.0.0 beta.

I originally commented most of this in https://github.com/adopted-ember-addons/ember-data-model-fragments/issues/375#issuecomment-940076666. Essentially if you have a model/fragment which has a fragment array/fragment property set to `null` it will never update when a http response has those properties updated. I have confirmed running these failing tests on a v4 branch pass just fine.

I've tracked the bug down to the following lines of code in the `FragmentRecordData#didCommit` hook:

https://github.com/adopted-ember-addons/ember-data-model-fragments/blob/4f77b2d5ea08685230ec60b5a3ddd2b3d3a7ec6c/addon/record-data.js#L426-L433

Basically because the existing property is set to `null` the `fragment = this.serverFragments[key];` evaluates to `null`. This means the `if (fragment)` check fails and we don't commit the new data to the fragment with `fragment._didCommit(attributes[key]);`.

So I've spiked out a potential solution but I'm unsure if this should be the direction I should be taking. I don't have as much context how Model Fragments/RecordData works so any pointers would be appreciated. Essentially we need to recreate the fragment or fragmentArray if it is `null` on the record and then re-set it on the record. The API of `createFragment`, for example, is `createFragment(store, declaredModelName, record, key, options, data)` but I can't find any possible way to get access to the `record` at this point in the stacktrace so I need to do some hacky stuff to get access to the host record, i.e. setting the `this._record` class property which, to be honest, seems a bit janky.

![image](https://user-images.githubusercontent.com/685034/136804944-34da746f-d698-47d7-9b56-1805e877c8a3.png)

It's also worth pointing out that I've ran this particular change against the Intercom test suite which has thousands of model fragment related tests and it works.

I've peppered comments throughout the source but this is more for comprehension for the reader. If I get an approval I'll remove any comments I don't think are necessary.