### PR TITLE
Fix fragment attributes in save response being ignored

### DIFF
--- a/addon/ext.js
+++ b/addon/ext.js
@@ -85,6 +85,11 @@ assign(RecordDataPrototype, {
   },
 
   didCommit(data) {
+    if (this._attributes) {
+      // willCommit was never called
+      this._inFlightAttributes = this._attributes;
+      this._attributes = null;
+    }
     this._isNew = false;
     if (data) {
       if (data.relationships) {
@@ -105,8 +110,7 @@ assign(RecordDataPrototype, {
 
     const changedKeys = this._changedKeys(data);
 
-    assign(this._data, this.__inFlightAttributes, this._attributes, data);
-    this._attributes = null;
+    assign(this._data, this._inFlightAttributes, data);
     this._inFlightAttributes = null;
     this._updateChangedAttributes();
 


### PR DESCRIPTION
Steps to reproduce:
1. Modify a fragment attribute and save
2. The server returns a different value for the attribute in its response

**Expected:** the fragment attribute should have the new value from the server (consistent with regular ED attributes outside of fragments)
**Actual:** the fragment attribute still has the locally modified value

The root cause seems to be `willCommit` not being called for fragments. `willCommit` is normally responsible for moving `_attributes` into `_inFlightAttributes`:
https://github.com/emberjs/data/blob/f56b22c4d6eefab8915ca48979f7d813f612971d/packages/record-data/addon/-private/record-data.ts#L120-L123

This is important because `_changedKeys` prefers to take `_attributes` over attributes in the response body:
https://github.com/emberjs/data/blob/f56b22c4d6eefab8915ca48979f7d813f612971d/packages/record-data/addon/-private/record-data.ts#L763-L769