### PR TITLE
fix: modelName undefined when serializing fragment

### DIFF
--- a/addon/transforms/fragment.js
+++ b/addon/transforms/fragment.js
@@ -35,7 +35,7 @@ const FragmentTransform = Transform.extend({
     }
 
     let store = this.store;
-    let serializer = store.serializerFor(snapshot.modelName);
+    let serializer = store.serializerFor(snapshot.modelName || snapshot.constructor.modelName);
 
     return serializer.serialize(snapshot);
   },


### PR DESCRIPTION
Resolves https://github.com/adopted-ember-addons/ember-data-model-fragments/issues/406