### PR TITLE
Pass arguments to `super.commitWasRejected` to get back `DS.Errors`

### DIFF
--- a/addon/record-data.js
+++ b/addon/record-data.js
@@ -458,7 +458,7 @@ export default class FragmentRecordData extends RecordData {
         }
       }
     }
-    return super.commitWasRejected();
+    return super.commitWasRejected(...arguments);
   }
 
   setAttr(key, value) {


### PR DESCRIPTION
We're having some failing tests with ember+ember-data @ 3.28 due to missing model errors.

These args seem to be necessary if I'm correct https://github.com/emberjs/data/blob/9889ebbd4eec162dba17bb00126ee71e49d04bce/packages/record-data/addon/-private/record-data.ts#L361
