### PR TITLE
[breaking][bugfix] respect null on server updates 

### DIFF
--- a/addon/record-data.js
+++ b/addon/record-data.js
@@ -232,7 +232,11 @@ export default class FragmentRecordData extends RecordData {
           let serverFragment = this.serverFragments[name];
           if (serverFragment) {
             let fragmentKeys = [];
-            if (serverFragment instanceof StatefulArray) {
+            if (data.attributes[name] === null) {
+              // if we have data with a Fragment set up, but now we've received null,
+              // delete the null fragment from serverFragments.
+              delete this.serverFragments[name];
+            } else if (serverFragment instanceof StatefulArray) {
               serverFragment.setupData(data.attributes[name]);
             } else {
               fragmentKeys = serverFragment._internalModel._recordData.pushData({ attributes: data.attributes[name] }, calculateChange);

--- a/tests/unit/fragment_array_test.js
+++ b/tests/unit/fragment_array_test.js
@@ -282,4 +282,66 @@ module('unit - `MF.fragmentArray`', function(hooks) {
       });
     });
   });
+
+  test('can be created with null', function(assert) {
+    let person = store.push({
+      data: {
+        type: 'person',
+        id: 1,
+        attributes: {
+          names: null
+        }
+      }
+    });
+
+    run(() => {
+      assert.strictEqual(person.names, null);
+    });
+  });
+
+  test('can be updated to null', function(assert) {
+    let person = store.push({
+      data: {
+        type: 'person',
+        id: 1,
+        attributes: {
+          names: [
+            {
+              first: 'Catelyn',
+              last: 'Tully'
+            },
+            {
+              first: 'Catelyn',
+              last: 'Stark'
+            }
+          ]
+        }
+      }
+    });
+
+    run(() => {
+      assert.deepEqual(person.names.toArray().map((f) => f.serialize()), [
+        {
+          'first': 'Catelyn',
+          'last': 'Tully'
+        },
+        {
+          'first': 'Catelyn',
+          'last': 'Stark'
+        }
+      ]);
+
+      store.push({
+        data: {
+          type: 'person',
+          id: 1,
+          attributes: {
+            names: null
+          }
+        }
+      });
+
+      assert.strictEqual(person.names, null);
+    });
+  });
 });

--- a/tests/unit/fragment_test.js
+++ b/tests/unit/fragment_test.js
@@ -307,4 +307,51 @@ module('unit - `MF.Fragment`', function(hooks) {
       assert.ok(person.get('names').isEvery('readyWasCalled'), 'when creating model that has fragmentArray');
     });
   });
+
+  test('can be created with null', async function(assert) {
+    let person = store.push({
+      data: {
+        type: 'person',
+        id: 1,
+        attributes: {
+          name: null
+        }
+      }
+    });
+
+    return run(() => {
+      assert.strictEqual(person.name, null);
+    });
+  });
+
+  test('can be updated to null', async function(assert) {
+    let person = store.push({
+      data: {
+        type: 'person',
+        id: 1,
+        attributes: {
+          name: {
+            first: 'Eddard',
+            last: 'Stark'
+          }
+        }
+      }
+    });
+
+    return run(() => {
+      assert.equal(person.name.first, 'Eddard');
+
+      store.push({
+        data: {
+          type: 'person',
+          id: 1,
+          attributes: {
+            name: null
+          }
+        }
+      });
+
+      assert.equal(person.name, null);
+    });
+  });
 });


### PR DESCRIPTION
Prior to this change, if a `fragment` was initialized with some value, and then server responds with a `null` it did not have any impact on a fragment state, and it kept having a non-empty value assigned. Now it's fixed, so the fragment attribute can be updated to `null`.

The same behavior is applied to the `fragmentArray`. Technically, this is a *breaking change*, since before, if non empty
`fragmentArray` received a `null` from the server, instead of nullifying the attribute, the `fragmentArray` instance just
became empty(with no items inside).

It was misaligned with how the `fragmentArray` handles `null` on create, cause during creation it is nullable. So for consistency, we let it be nullable on updates as well.