### PR TITLE
Do not fail CI on Ember release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,12 +184,14 @@ jobs:
           ember-3.13,
           ember-lts-3.16,
           ember-lts-3.20,
-          ember-release,
+          ember-lts-3.24,
           ember-default-with-jquery,
           ember-classic
         ]
         allow-failure: [false]
         include:
+          - ember-try-scenario: ember-release
+            allow-failure: true
           - ember-try-scenario: ember-beta
             allow-failure: true
           - ember-try-scenario: ember-canary

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Use the following table to decide which version of this project to use with your
 | >= v3.2.x < v3.4.x | v3.3.x |
 | >= v3.5.x < v3.12.x | v4.0.x |
 | >= v3.13.x | v5.0.x |
+| >= v3.28.x | Not fully compatible (See [issue](https://github.com/adopted-ember-addons/ember-data-model-fragments/issues/406)) |
 
 #### Notes
 

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -34,6 +34,16 @@ module.exports = async function() {
         }
       },
       {
+        name: 'ember-lts-3.24',
+        npm: {
+          devDependencies: {
+            'ember-source': '~3.24.6',
+            'ember-data': '~3.24.0'
+          }
+        }
+      },
+      // @patocallaghan - Allow ember-release to fail release until we resolve https://github.com/adopted-ember-addons/ember-data-model-fragments/issues/406
+      {
         name: 'ember-release',
         npm: {
           devDependencies: {


### PR DESCRIPTION
@knownasilya Any thoughts on this?

Until https://github.com/adopted-ember-addons/ember-data-model-fragments/issues/406 is resolved CI is 🔴. Should we disable testing against Ember Data release until we land a fix there? It will remove noise on any PRs we land in the meantime. I think we should continue testing against ember-source release though

I've also added a note to the README about 3.28 not being fully supported yet

Edit: I've changed to opt out of ember-release altogether as lots of changes are required to make the test suite run in ember 4.0