### PR TITLE
fix: handle current state not yet set

### DIFF
--- a/addon/array/stateful.js
+++ b/addon/array/stateful.js
@@ -179,6 +179,11 @@ const StatefulArray = ArrayProxy.extend(Copyable, {
     let record = get(this, 'owner');
     let key = get(this, 'name');
 
+    // Abort if fragment is still initializing
+    if (record._internalModel._recordData.isStillInitializing(key)) {
+      return;
+    }
+
     // Any change to the size of the fragment array means a potential state change
     if (get(this, 'hasDirtyAttributes')) {
       fragmentDidDirty(record, key, this);

--- a/addon/record-data.js
+++ b/addon/record-data.js
@@ -120,10 +120,12 @@ export default class FragmentRecordData extends RecordData {
       assert('A fragment array property can only be assigned an array or null');
     }
 
-    if (this.serverFragments[key] !== fragments || get(fragments, 'hasDirtyAttributes')) {
-      fragmentDidDirty(record, key, fragments);
-    } else {
-      fragmentDidReset(record, key);
+    if (!record._internalModel._recordData.isStillInitializing(key)) {
+      if (this.serverFragments[key] !== fragments || get(fragments, 'hasDirtyAttributes')) {
+        fragmentDidDirty(record, key, fragments);
+      } else {
+        fragmentDidReset(record, key);
+      }
     }
 
     return fragments;
@@ -168,11 +170,13 @@ export default class FragmentRecordData extends RecordData {
 
     let currentFragment = this.getFragment(key, options, declaredModelName, record);
 
-    if (currentFragment !== fragment) {
-      this.fragments[key] = fragment;
-      fragmentDidDirty(record, key, fragment);
-    } else {
-      fragmentDidReset(record, key);
+    if (!record._internalModel._recordData.isStillInitializing(key)) {
+      if (currentFragment !== fragment) {
+        this.fragments[key] = fragment;
+        fragmentDidDirty(record, key, fragment);
+      } else {
+        fragmentDidReset(record, key);
+      }
     }
     return fragment;
   }
@@ -227,6 +231,10 @@ export default class FragmentRecordData extends RecordData {
     } else if (this.serverFragments[key] !== undefined) {
       return this.serverFragments[key];
     }
+  }
+
+  isStillInitializing(key) {
+    return !this.getFragmentWithoutCreating(key) || !this._record.___recordState;
   }
   // PUBLIC API
 

--- a/addon/states.js
+++ b/addon/states.js
@@ -13,6 +13,7 @@ const dirtySetup = function(internalModel) {
   let record = internalModel._recordData._owner;
   let key = internalModel._recordData._name;
 
+  console.log('dirtySetup');
   // A newly created fragment may not have an owner yet
   if (record) {
     fragmentDidDirty(record, key, internalModel);
@@ -87,7 +88,7 @@ let FragmentRootState = {
         let key = internalModel._recordData._name;
 
         // Abort if fragment is still initializing
-        if (!record._internalModel._recordData.getFragmentWithoutCreating(key)) {
+        if (record._internalModel._recordData.isStillInitializing(key)) {
           return;
         }
 


### PR DESCRIPTION
When doing the following:
```js
    const user = store.createRecord('user', {
      id: 1,
      firstName: 'Vince',
      lastName: 'Mol',
      email: 'firstLast@forestadmin.com',
      permissions: ['editProject'], // This is an `array` from fragment
    });
```
`ember-data-model-fragments` crash in that case because the `currentState` is not yet setup as the init of the record is not yet called but we try to access it in `fragmentDidDirty` and `fragmentDidReset`.

To fix it I first thought of just handling this case in the `fragmentDidDirty` and `fragmentDidReset`. But it actually makes no sense I think. So I added a new method `isStillInitializing` to prevent calling `fragmentDidDirty` and `fragmentDidReset` when the record is not yet initialized.