### PR TITLE
feat(polymorphism): add the possibility to compute the type based on owner and data

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,6 +456,8 @@ However, note that fragments do not currently support `belongsTo` or `hasMany` p
 Ember Data: Model Fragments has support for *reading* polymorphic fragments. To use this feature, pass an options object to `fragment` or `fragmentArray`
 with `polymorphic` set to true. In addition the `typeKey` can be set, which defaults to `'type'`.
 
+The `typeKey` option might be a `String` or a `Function` returning a `String`. If you use a function, the `data` and the `owner` will be passed as parameter.
+
 The `typeKey`'s value must be the lowercase name of a class that is assignment-compatible to the declared type of the fragment attribute. That is, it must be the declared type itself or a subclass. Additionally, the `typeKey`'s value must be a field on the parent class.
 
 In the following example the declared type of `animals` is `animal`, which corresponds to the class `Animal`. `Animal` has two subclasses: `Elephant` and `Lion`,
@@ -471,6 +473,7 @@ export default Model.extend({
   name: attr('string'),
   city: attr('string'),
   animals: fragmentArray('animal', { polymorphic: true, typeKey: '$type' }),
+  bestAnimal: fragment('animal', { polymorphic: true, typeKey: (data) => `my-model-prefix-${data.name}` })
 });
 ```
 

--- a/addon/fragment.js
+++ b/addon/fragment.js
@@ -165,8 +165,6 @@ export function getActualFragmentType(declaredType, options, data, owner) {
   }
 
   let typeKey = options.typeKey || 'type';
-  console.log('data', data);
-  console.log('owner', owner);
   let actualType = typeof typeKey === 'function' ? typeKey(data, owner) : data[typeKey];
 
   return actualType || declaredType;

--- a/addon/fragment.js
+++ b/addon/fragment.js
@@ -159,13 +159,15 @@ const Fragment = Model.extend(Ember.Comparable, Copyable, {
  * @param {Object} data the fragment data
  * @return {String} the actual fragment type
  */
-export function getActualFragmentType(declaredType, options, data) {
+export function getActualFragmentType(declaredType, options, data, owner) {
   if (!options.polymorphic || !data) {
     return declaredType;
   }
 
   let typeKey = options.typeKey || 'type';
-  let actualType = data[typeKey];
+  console.log('data', data);
+  console.log('owner', owner);
+  let actualType = typeof typeKey === 'function' ? typeKey(data, owner) : data[typeKey];
 
   return actualType || declaredType;
 }
@@ -201,7 +203,7 @@ export function setFragmentData(fragment, data) {
 
 // Creates a fragment and sets its owner to the given record
 export function createFragment(store, declaredModelName, record, key, options, data) {
-  let actualModelName = getActualFragmentType(declaredModelName, options, data);
+  let actualModelName = getActualFragmentType(declaredModelName, options, data, record);
   let fragment = store.createFragment(actualModelName);
 
   setFragmentOwner(fragment, record, key);


### PR DESCRIPTION
This PR enables the following:
```js
export default class Monster extends Model {
  @attr('string') monsterType;

  @fragment('characteristic', { polymorphic: true, typeKey: (data, owner) => `${owner.monsterType}-characteristics` })
  characteristics;

  @fragmentArray('quality', { polymorphic: true, typeKey: (data, owner) => `${data.qualityType}-quality` })
  qualities;
});
```