### PR TITLE
fix(dirty state): prevent record from being tagged as dirty when not changed

### DIFF
--- a/addon/ext.js
+++ b/addon/ext.js
@@ -85,14 +85,13 @@ assign(RecordDataPrototype, {
   },
 
   didCommit(data) {
-    // It seems the will commit has changed because _attributes
-    // is actually not set to null but just empty
-    const shouldSetInFlightAttributes = gte('ember-data', '3.28.0') ?
-      this._attributes && !this._inFlightAttributes :
-      this._attributes;
-    if (shouldSetInFlightAttributes) {
+    if (this._attributes) {
       // willCommit was never called
-      this._inFlightAttributes = this._attributes;
+      if (!this._inFlightAttributes) {
+        this._inFlightAttributes = this._attributes;
+      } else {
+        assign(this._inFlightAttributes, this._attributes);
+      }
       this._attributes = null;
     }
     this._isNew = false;


### PR DESCRIPTION
This commit: https://github.com/adopted-ember-addons/ember-data-model-fragments/commit/f64a15ed57671923e7f630c9a5277541ea506bd4 introduced an issue on the dirty state. The attribute `_data` was always overridden even if the server does not send any data. 
This means that whenever you get a 204, the current state was `_data = {}` (an empty json). So whenever we try to update a property even to the same value the record is marked as dirty and the `changedAttributes` old value was always `undefined`