### PR TITLE
fix(dirty state): fix dirtyness after save when using polymorphic fragment in some specific use case

### DIFF
--- a/addon/ext.js
+++ b/addon/ext.js
@@ -45,8 +45,7 @@ const RecordDataPrototype = RecordData.prototype;
 
 assign(RecordDataPrototype, {
   eachFragmentKey(fn) {
-    this._fragments = this._fragments || Object.create({});
-    Object.keys(this._fragments).forEach(fn);
+    Object.keys(this.fragments).forEach(fn);
   },
 
   eachFragmentKeyValue(fn) {
@@ -75,14 +74,7 @@ assign(RecordDataPrototype, {
   },
 
   getFragment(name) {
-    this._fragments = this._fragments || Object.create({});
-    return this._fragments[name];
-  },
-
-  setFragment(name, fragment) {
-    this._fragments = this._fragments || Object.create({});
-    this._fragments[name] = fragment;
-    return this._fragments[name];
+    return this.fragments[name];
   },
 
   didCommit(data) {

--- a/tests/dummy/app/models/component-options-chart.js
+++ b/tests/dummy/app/models/component-options-chart.js
@@ -1,0 +1,6 @@
+import ComponentOptions from './component-options';
+import MF from 'ember-data-model-fragments';
+
+export default class ComponentOptionsChart extends ComponentOptions {
+  @MF.fragment('order') lastOrder;
+}

--- a/tests/integration/save_test.js
+++ b/tests/integration/save_test.js
@@ -856,4 +856,39 @@ module('integration - Persistence', function(hooks) {
     army.set('soldiers', ['Aegor Rivers', 'Jon Connington', 'Tristan Rivers']);
     run(() => army.save());
   });
+
+  test('initializing a fragment, saving and then updating that fragment', async function(assert) {
+    const component = store.createRecord('component', { id: 10, type: 'chart', options: {} });
+
+    server.post('/components', () => [204]);
+    server.put('/components/:id', () => [204]);
+
+    await component.save();
+
+    assert.ok(
+      !component.get('hasDirtyAttributes'),
+      'component record is not dirty'
+    );
+
+    component.options.lastOrder = { products: [] };
+    component.options.lastOrder.products.pushObject({ name: 'Light Saber' });
+
+    assert.ok(
+      component.get('hasDirtyAttributes'),
+      'component record is dirty'
+    );
+
+    await component.save();
+
+    assert.ok(
+      !component.get('hasDirtyAttributes'),
+      'component record is not dirty after save'
+    );
+
+    component.options.lastOrder.products.createFragment({ name: 'Baby Yoda' });
+    assert.ok(
+      component.get('hasDirtyAttributes'),
+      'component record is dirty'
+    );
+  });
 });


### PR DESCRIPTION
Some code was not updated. It seems `_fragments` has been replaced by `fragments` property but in some places we still use `_fragments`. The thing is when didCommit is called it use the `_fragments` to notify the nested attributes they were not dirty anymore 