### PR TITLE
fix(polymorphic): update of type of a polymorphic key works

### DIFF
--- a/addon/ext.js
+++ b/addon/ext.js
@@ -82,7 +82,7 @@ Object.assign(RecordDataPrototype, {
       if (!this._inFlightAttributes) {
         this._inFlightAttributes = this._attributes;
       } else {
-        assign(this._inFlightAttributes, this._attributes);
+        Object.assign(this._inFlightAttributes, this._attributes);
       }
       this._attributes = null;
     }

--- a/addon/record-data.js
+++ b/addon/record-data.js
@@ -144,12 +144,14 @@ export default class FragmentRecordData extends RecordData {
         isInstanceOfType(store.modelFor(declaredModelName), value)
     );
 
+    // If the fragment was null before or if the new value i not of the same model as the previous one (polymorphism) we should recreate the fragment.
+    const shouldRecreateFragment = !fragment || (getActualFragmentType(declaredModelName, options, value, record) !== fragment.constructor.modelName);
     if (!value) {
       fragment = null;
     } else if (isFragment(value)) {
       // A fragment instance was given, so just replace the existing value
       fragment = setFragmentOwner(value, record, key);
-    } else if (!fragment || (getActualFragmentType(declaredModelName, options, value, record) !== fragment.constructor.modelName)) {
+    } else if (shouldRecreateFragment) {
       // A property hash was given but the property was null, so create a new
       // fragment with the data
       fragment = createFragment(

--- a/addon/record-data.js
+++ b/addon/record-data.js
@@ -144,7 +144,7 @@ export default class FragmentRecordData extends RecordData {
         isInstanceOfType(store.modelFor(declaredModelName), value)
     );
 
-    // If the fragment was null before or if the new value i not of the same model as the previous one (polymorphism) we should recreate the fragment.
+    // If the fragment was null before or if the new value is not of the same model as the previous one (polymorphism) we should recreate the fragment.
     const shouldRecreateFragment = !fragment || (getActualFragmentType(declaredModelName, options, value, record) !== fragment.constructor.modelName);
     if (!value) {
       fragment = null;

--- a/addon/record-data.js
+++ b/addon/record-data.js
@@ -12,7 +12,8 @@ import FragmentArray from './array/fragment';
 import {
   setFragmentOwner,
   createFragment,
-  isFragment
+  isFragment,
+  getActualFragmentType
 } from './fragment';
 import { gte } from 'ember-compatibility-helpers';
 
@@ -148,7 +149,7 @@ export default class FragmentRecordData extends RecordData {
     } else if (isFragment(value)) {
       // A fragment instance was given, so just replace the existing value
       fragment = setFragmentOwner(value, record, key);
-    } else if (!fragment) {
+    } else if (!fragment || (getActualFragmentType(declaredModelName, options, value, record) !== fragment.constructor.modelName)) {
       // A property hash was given but the property was null, so create a new
       // fragment with the data
       fragment = createFragment(

--- a/tests/unit/fragment_test.js
+++ b/tests/unit/fragment_test.js
@@ -5,6 +5,8 @@ import Ember from 'ember';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import Pretender from 'pretender';
+import Lion from 'dummy/models/lion';
+import Elephant from 'dummy/models/elephant';
 
 let store;
 
@@ -417,6 +419,44 @@ module('unit - `MF.Fragment`', function(hooks) {
       assert.equal(person.nickName, 'Johnner', 'nickName is correctly loaded');
       assert.deepEqual(person.name.serialize(), { first: 'John', last: 'Doe', prefixes: [{ name: 'Mr.' }, { name: 'Sir' }] }, 'name is correctly loaded');
       assert.deepEqual(person.names.serialize(), [{ first: 'John', last: 'Doe', prefixes: [] }], 'names is correct');
+    });
+  });
+
+  module('polymorphic', function() {
+    module('when updating the type of the model', function() {
+      test('it should rebuild the fragment', async function(assert) {
+        const zoo = store.push({
+          data: {
+            type: 'zoo',
+            id: 1,
+            attributes: {
+              name: 'Cincinnati Zoo',
+              star: {
+                $type: 'elephant',
+                name: 'Sabu'
+              }
+            },
+            relationships: {
+              manager: {
+                data: { type: 'person', id: 1 }
+              }
+            }
+          }
+        });
+
+        assert.ok(zoo.star instanceof Elephant);
+        assert.strictEqual(zoo.star.name, 'Sabu');
+
+        zoo.star = {
+          $type: 'lion',
+          hasManes: true
+        };
+
+        assert.ok(zoo.star instanceof Lion);
+        assert.strictEqual(zoo.star.name, undefined);
+        assert.strictEqual(zoo.star.hasManes, true);
+
+      });
     });
   });
 });


### PR DESCRIPTION
Updating a fragment to something that should be another fragment type doesn't work. I just make sure that when setting a fragment value the type is the same otherwise recreate the fragment 