### PR TITLE
Handle null record in isStateInitializing

### DIFF
--- a/addon/record-data.js
+++ b/addon/record-data.js
@@ -238,7 +238,7 @@ export default class FragmentRecordData extends RecordData {
   }
 
   isStateInitializing() {
-    return gte('ember-data', '3.28.0') && !this._record.___recordState;
+    return gte('ember-data', '3.28.0') && !this._record?.___recordState;
   }
 
   // PUBLIC API


### PR DESCRIPTION
Had a problem in our codebase that was hitting null `_record` here with a fragment in testing. 