### PR TITLE
Fix glimmer render error when creating fragment arrays

### DIFF
--- a/addon/array/stateful.js
+++ b/addon/array/stateful.js
@@ -81,9 +81,15 @@ const StatefulArray = EmberObject.extend(MutableArray, Copyable, {
     return this._length;
   },
 
-  setObjects(objects) {
-    // this override avoids calling `length`, which sets up auto tracking
-    // see https://github.com/adopted-ember-addons/ember-data-model-fragments/pull/466
+  /**
+   * Unlike `setObjects`, this method avoids setting up auto-tracking,
+   * which prevents a glimmer rendering error in some circumstances.
+   * @see https://github.com/adopted-ember-addons/ember-data-model-fragments/pull/466
+   * @param objects the new array contents
+   * @return {StatefulArray} this instance
+   * @private
+   */
+  _setFragments(objects) {
     if (this._isDirty) {
       this.retrieveLatest();
     }

--- a/addon/array/stateful.js
+++ b/addon/array/stateful.js
@@ -86,7 +86,6 @@ const StatefulArray = EmberObject.extend(MutableArray, Copyable, {
    * which prevents a glimmer rendering error in some circumstances.
    * @see https://github.com/adopted-ember-addons/ember-data-model-fragments/pull/466
    * @param objects the new array contents
-   * @return {StatefulArray} this instance
    * @private
    */
   _setFragments(objects) {
@@ -94,7 +93,6 @@ const StatefulArray = EmberObject.extend(MutableArray, Copyable, {
       this.retrieveLatest();
     }
     this.replace(0, this._length, objects);
-    return this;
   },
 
   objectAt(index) {

--- a/addon/array/stateful.js
+++ b/addon/array/stateful.js
@@ -81,6 +81,16 @@ const StatefulArray = EmberObject.extend(MutableArray, Copyable, {
     return this._length;
   },
 
+  setObjects(objects) {
+    // this override avoids calling `length`, which sets up auto tracking
+    // see https://github.com/adopted-ember-addons/ember-data-model-fragments/pull/466
+    if (this._isDirty) {
+      this.retrieveLatest();
+    }
+    this.replace(0, this._length, objects);
+    return this;
+  },
+
   objectAt(index) {
     if (this._isDirty) {
       this.retrieveLatest();
@@ -97,6 +107,10 @@ const StatefulArray = EmberObject.extend(MutableArray, Copyable, {
       'The third argument to replace needs to be an array.',
       isArray(items)
     );
+    if (deleteCount === 0 && items.length === 0) {
+      // array is unchanged
+      return;
+    }
     const data = this.currentState.slice();
     data.splice(
       start,

--- a/addon/attributes/array.js
+++ b/addon/attributes/array.js
@@ -90,7 +90,7 @@ export default function array(type, options) {
         });
         recordData._fragmentArrayCache[key] = array;
       }
-      array.setObjects(value);
+      array._setFragments(value);
       return array;
     },
   }).meta(meta);

--- a/addon/attributes/fragment-array.js
+++ b/addon/attributes/fragment-array.js
@@ -102,7 +102,7 @@ export default function fragmentArray(type, options) {
         });
         recordData._fragmentArrayCache[key] = fragmentArray;
       }
-      fragmentArray.setObjects(value);
+      fragmentArray._setFragments(value);
       return fragmentArray;
     },
   }).meta(meta);

--- a/tests/integration/render_test.js
+++ b/tests/integration/render_test.js
@@ -1,0 +1,111 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from '../helpers';
+import { render, settled } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { setComponentTemplate } from '@ember/component';
+import Component from '@glimmer/component';
+
+module('Integration | Rendering', function (hooks) {
+  setupRenderingTest(hooks);
+
+  let store;
+
+  hooks.beforeEach(function () {
+    store = this.owner.lookup('service:store');
+  });
+
+  hooks.afterEach(function () {
+    store = null;
+  });
+
+  test('construct fragments without autotracking.mutation-after-consumption error', async function (assert) {
+    class PersonComponent extends Component {
+      constructor() {
+        super(...arguments);
+        this.person = store.createRecord('person', {
+          name: {
+            first: 'Tyrion',
+            last: 'Lannister',
+          },
+          titles: ['Hand of the King', 'Master of Coin'],
+        });
+      }
+
+      willDestroy() {
+        this.person.unloadRecord();
+        super.willDestroy(...arguments);
+      }
+    }
+    setComponentTemplate(hbs`{{yield this.person}}`, PersonComponent);
+
+    this.Person = PersonComponent;
+    this.show = false;
+
+    await render(hbs`
+      {{#if this.show}}
+        <this.Person as |person|>
+          <h3 data-name>{{person.name.first}} {{person.name.last}}</h3>
+          <ul>
+            {{#each person.titles as |title idx|}}
+              <li data-title="{{idx}}">{{title}}</li>
+            {{/each}}
+          </ul>
+        </this.Person>
+      {{/if}}
+    `);
+
+    assert.dom().hasNoText();
+
+    this.set('show', true);
+
+    assert.dom('[data-name]').hasText('Tyrion Lannister');
+    assert.dom('[data-title]').exists({ count: 2 });
+    assert.dom('[data-title="0"]').hasText('Hand of the King');
+    assert.dom('[data-title="1"]').hasText('Master of Coin');
+  });
+
+  test('fragment array computed property', async function (assert) {
+    class OrderListComponent extends Component {
+      get productsByPrice() {
+        const { order } = this.args;
+        return order.products.sortBy('price');
+      }
+    }
+    setComponentTemplate(
+      hbs`
+        <ul>
+          {{#each this.productsByPrice as |product idx|}}
+            <li data-product="{{idx}}">{{product.name}}: {{product.price}}</li>
+          {{/each}}
+        </ul>
+      `,
+      OrderListComponent
+    );
+
+    this.OrderList = OrderListComponent;
+    this.order = store.createRecord('order');
+
+    await render(hbs`<this.OrderList @order={{this.order}}/>`);
+
+    assert.dom('[data-product]').doesNotExist();
+
+    this.order.products.createFragment({
+      name: 'Tears of Lys',
+      price: '499.99',
+    });
+    await settled();
+
+    assert.dom('[data-product]').exists({ count: 1 });
+    assert.dom('[data-product="0"]').hasText('Tears of Lys: 499.99');
+
+    this.order.products.createFragment({
+      name: 'The Strangler',
+      price: '299.99',
+    });
+    await settled();
+
+    assert.dom('[data-product]').exists({ count: 2 });
+    assert.dom('[data-product="0"]').hasText('The Strangler: 299.99');
+    assert.dom('[data-product="1"]').hasText('Tears of Lys: 499.99');
+  });
+});

--- a/tests/integration/render_test.js
+++ b/tests/integration/render_test.js
@@ -30,11 +30,6 @@ module('Integration | Rendering', function (hooks) {
           titles: ['Hand of the King', 'Master of Coin'],
         });
       }
-
-      willDestroy() {
-        this.person.unloadRecord();
-        super.willDestroy(...arguments);
-      }
     }
     setComponentTemplate(hbs`{{yield this.person}}`, PersonComponent);
 


### PR DESCRIPTION
Fixes https://github.com/adopted-ember-addons/ember-data-model-fragments/issues/357

Constructing a record throws an error:
```js
store.createRecord('person', {
  titles: ['Hand of the King', 'Master of Coin'],
});
```
```
Error: Assertion Failed: You attempted to update `[]` on `<(unknown):ember176:owner(null)>`, but it had already been used previously in the same computation.  Attempting to update a value after using it in a computation can cause logical errors, infinite revalidation bugs, and performance issues, and is not supported.

`[]` was first used:

- While rendering:
  -top-level
    application
      index
        PersonComponent

Stack trace for the update:
    at dirtyTagFor (http://localhost:4201/assets/vendor.js:49934:37)
    at markObjectAsDirty (http://localhost:4201/assets/vendor.js:9751:32)
    at notifyPropertyChange (http://localhost:4201/assets/vendor.js:9794:5)
    at Class.notifyPropertyChange (http://localhost:4201/assets/vendor.js:22511:39)
    at Class.notify (http://localhost:4201/assets/vendor.js:85031:14)
    at Class.replace (http://localhost:4201/assets/vendor.js:85059:12)
    at Class.setObjects (http://localhost:4201/assets/vendor.js:21903:12)
```

This happens when we initialize a fragment array while a render loop is running.
