### PR TITLE
Fix issue with reloading array records.

### DIFF
--- a/addon/record-data.js
+++ b/addon/record-data.js
@@ -692,7 +692,10 @@ export default class FragmentRecordData extends RecordData {
       if (this._fragments[key]) {
         continue;
       }
-      if ((updates[key] === null) !== (original[key] === null)) {
+      if (
+        (updates[key] === null) !== (original[key] === null) ||
+        updates[key] !== original[key]
+      ) {
         changedKeys.push(key);
       }
     }
@@ -724,7 +727,12 @@ export default class FragmentRecordData extends RecordData {
       if (calculateChange) {
         changedFragmentKeys = this._changedFragmentKeys(newCanonicalFragments);
       }
+
       Object.assign(this._fragmentData, newCanonicalFragments);
+      // update fragment arrays
+      Object.keys(newCanonicalFragments).forEach((key) =>
+        this._fragmentArrayCache[key]?.notify()
+      );
     }
 
     const changedAttributeKeys = super.pushData(data, calculateChange);

--- a/addon/record-data.js
+++ b/addon/record-data.js
@@ -692,10 +692,7 @@ export default class FragmentRecordData extends RecordData {
       if (this._fragments[key]) {
         continue;
       }
-      if (
-        (updates[key] === null) !== (original[key] === null) ||
-        updates[key] !== original[key]
-      ) {
+      if ((updates[key] === null) !== (original[key] === null)) {
         changedKeys.push(key);
       }
     }

--- a/tests/integration/save_test.js
+++ b/tests/integration/save_test.js
@@ -709,10 +709,8 @@ module('integration - Persistence', function (hooks) {
     return person.save();
   });
 
-  // TODO(igor) figure out why length is different the first time this assertion is called.
-  skip('fragment array properties are notified on reload', async function (assert) {
-    // The extra assertion comes from deprecation checking
-    // assert.expect(2);
+  test('fragment array properties are notified on reload', async function (assert) {
+    assert.expect(1);
     class Army extends Model {
       @attr('string') name;
       @array() soldiers;

--- a/tests/integration/save_test.js
+++ b/tests/integration/save_test.js
@@ -710,7 +710,8 @@ module('integration - Persistence', function (hooks) {
   });
 
   test('fragment array properties are notified on reload', async function (assert) {
-    assert.expect(1);
+    // different ember versions include deprecation checks that cause this count to change
+    // assert.expect(1);
     class Army extends Model {
       @attr('string') name;
       @array() soldiers;


### PR DESCRIPTION
I was looking at getting [reloading for fragment arrays working](https://github.com/adopted-ember-addons/ember-data-model-fragments/issues/467), and I think I stumbled across a bug.

This conditional:
```
 if ((updates[key] === null) !== (original[key] === null))
```
it wasn't catching when the array existed and was different, so I added another condition `(updates[key] !== original[key])`. This updated the `_fragmentData` properly, but the cache was still being used so updates weren't making it through. I nabbed some code to clear the cache and the test started passing.