### PR TITLE
changedAttributes still return the dirty attributes until the record has been fully committed

### DIFF
--- a/addon/record-data.js
+++ b/addon/record-data.js
@@ -619,7 +619,7 @@ export default class FragmentRecordData extends RecordData {
 
   hasChangedFragments() {
     return (
-      this.__fragments !== null && Object.keys(this.__fragments).length > 0
+      this._fragmentsOrInFlight !== null && Object.keys(this._fragmentsOrInFlight).length > 0
     );
   }
 
@@ -669,7 +669,7 @@ export default class FragmentRecordData extends RecordData {
 
   changedFragments() {
     const diffData = Object.create(null);
-    for (const [key, newFragment] of Object.entries(this._fragments)) {
+    for (const [key, newFragment] of Object.entries(this._fragmentsOrInFlight || {})) {
       const behavior = this._fragmentBehavior[key];
       const oldFragment =
         key in this._inFlightFragments
@@ -1051,6 +1051,10 @@ export default class FragmentRecordData extends RecordData {
 
   set _inFlightFragments(v) {
     this.__inFlightFragments = v;
+  }
+
+  get _fragmentsOrInFlight() {
+    return (this.__inFlightFragments && Object.keys(this.__inFlightFragments).length > 0) ? this.__inFlightFragments : this.__fragments;
   }
 
   /**

--- a/addon/record-data.js
+++ b/addon/record-data.js
@@ -618,9 +618,7 @@ export default class FragmentRecordData extends RecordData {
   }
 
   hasChangedFragments() {
-    return (
-      this._fragmentsOrInFlight !== null && Object.keys(this._fragmentsOrInFlight).length > 0
-    );
+    return Object.keys(this._fragmentsOrInFlight).length > 0;
   }
 
   isFragmentDirty(key) {
@@ -669,7 +667,9 @@ export default class FragmentRecordData extends RecordData {
 
   changedFragments() {
     const diffData = Object.create(null);
-    for (const [key, newFragment] of Object.entries(this._fragmentsOrInFlight || {})) {
+    for (const [key, newFragment] of Object.entries(
+      this._fragmentsOrInFlight
+    )) {
       const behavior = this._fragmentBehavior[key];
       const oldFragment =
         key in this._inFlightFragments
@@ -1054,7 +1054,10 @@ export default class FragmentRecordData extends RecordData {
   }
 
   get _fragmentsOrInFlight() {
-    return (this.__inFlightFragments && Object.keys(this.__inFlightFragments).length > 0) ? this.__inFlightFragments : this.__fragments;
+    return this.__inFlightFragments &&
+      Object.keys(this.__inFlightFragments).length > 0
+      ? this.__inFlightFragments
+      : this.__fragments || {};
   }
 
   /**

--- a/tests/dummy/app/models/component.js
+++ b/tests/dummy/app/models/component.js
@@ -2,6 +2,7 @@ import Model, { attr } from '@ember-data/model';
 import { fragment } from 'ember-data-model-fragments/attributes';
 
 export default class Component extends Model {
+  @attr('string') name;
   @attr('string') type;
   @fragment('component-options', {
     polymorphic: true,

--- a/tests/dummy/app/serializers/component.js
+++ b/tests/dummy/app/serializers/component.js
@@ -1,3 +1,21 @@
 import JSONAPISerializer from '@ember-data/serializer/json-api';
 
-export default class extends JSONAPISerializer {}
+export default class extends JSONAPISerializer {
+  serialize(snapshot, ...args) {
+    const data = super.serialize(snapshot, ...args);
+    const { record } = snapshot;
+
+    if (data.data?.attributes) {
+        // NOTICE: Remove all the unchanged attributes in the payload.
+        const changedAttributes = Object.keys(record.changedAttributes());
+
+        Object.entries(data.data.attributes).forEach(([attributeName, value]) => {
+          if (!changedAttributes.includes(attributeName)) {
+            delete data.data.attributes[attributeName];
+          }
+        });
+    }
+
+    return data;
+  }
+}

--- a/tests/dummy/app/serializers/component.js
+++ b/tests/dummy/app/serializers/component.js
@@ -6,14 +6,14 @@ export default class extends JSONAPISerializer {
     const { record } = snapshot;
 
     if (data.data?.attributes) {
-        // NOTICE: Remove all the unchanged attributes in the payload.
-        const changedAttributes = Object.keys(record.changedAttributes());
+      // NOTICE: Remove all the unchanged attributes in the payload.
+      const changedAttributes = Object.keys(record.changedAttributes());
 
-        Object.entries(data.data.attributes).forEach(([attributeName, value]) => {
-          if (!changedAttributes.includes(attributeName)) {
-            delete data.data.attributes[attributeName];
-          }
-        });
+      Object.keys(data.data.attributes).forEach((attributeName) => {
+        if (!changedAttributes.includes(attributeName)) {
+          delete data.data.attributes[attributeName];
+        }
+      });
     }
 
     return data;

--- a/tests/unit/serialize_test.js
+++ b/tests/unit/serialize_test.js
@@ -4,6 +4,7 @@ import { setupApplicationTest } from '../helpers';
 import JSONSerializer from '@ember-data/serializer/json';
 import Person from 'dummy/models/person';
 import { fragmentArray, array } from 'ember-data-model-fragments/attributes';
+import Pretender from 'pretender';
 // eslint-disable-next-line ember/use-ember-data-rfc-395-imports
 import DS from 'ember-data';
 let store, owner;
@@ -318,5 +319,68 @@ module('unit - Serialization', function (hooks) {
       }),
       'fragment property values are normalized'
     );
+  });
+
+  module('when saving the record', function (saveHooks) {
+    let server;
+
+    saveHooks.beforeEach(function () {
+      server = new Pretender();
+    });
+  
+    saveHooks.afterEach(function () {
+      server.shutdown();
+    });
+
+    test('changedAttributes should have the same result when serialized as before the save is called', async function (assert) {
+      assert.expect(3);
+      
+      store.pushPayload('component', {
+        data: {
+          type: 'components',
+          id: 1,
+          attributes: {
+            name: 'mine',
+            type: 'text',
+            options: {
+              fontFamily: 'roman',
+              fontSize: 12,
+            },
+          },
+        },
+      });
+      const component = store.peekRecord('component', 1);
+
+      component.options.fontFamily = 'sans-serif';
+
+      assert.deepEqual(component.changedAttributes(), {
+        options: [{
+          fontFamily: 'roman',
+          fontSize: 12,
+        }, {
+          fontFamily: 'sans-serif',
+          fontSize: 12,
+        }],
+      });
+
+      server.put('/components/1', (request) => {
+        assert.deepEqual(JSON.parse(request.requestBody), {
+          data: {
+            type: 'components',
+            attributes: {
+              options: {
+                fontFamily: 'sans-serif',
+                fontSize: 12,
+              },
+            }
+          }
+        });
+        return [204, { 'Content-Type': 'application/json' }, '{}'];
+      });
+
+      await component.save();
+
+      assert.deepEqual(component.changedAttributes(), {});
+    })
   });
 });

--- a/tests/unit/serialize_test.js
+++ b/tests/unit/serialize_test.js
@@ -327,14 +327,14 @@ module('unit - Serialization', function (hooks) {
     saveHooks.beforeEach(function () {
       server = new Pretender();
     });
-  
+
     saveHooks.afterEach(function () {
       server.shutdown();
     });
 
     test('changedAttributes should have the same result when serialized as before the save is called', async function (assert) {
       assert.expect(3);
-      
+
       store.pushPayload('component', {
         data: {
           type: 'components',
@@ -354,13 +354,16 @@ module('unit - Serialization', function (hooks) {
       component.options.fontFamily = 'sans-serif';
 
       assert.deepEqual(component.changedAttributes(), {
-        options: [{
-          fontFamily: 'roman',
-          fontSize: 12,
-        }, {
-          fontFamily: 'sans-serif',
-          fontSize: 12,
-        }],
+        options: [
+          {
+            fontFamily: 'roman',
+            fontSize: 12,
+          },
+          {
+            fontFamily: 'sans-serif',
+            fontSize: 12,
+          },
+        ],
       });
 
       server.put('/components/1', (request) => {
@@ -372,8 +375,8 @@ module('unit - Serialization', function (hooks) {
                 fontFamily: 'sans-serif',
                 fontSize: 12,
               },
-            }
-          }
+            },
+          },
         });
         return [204, { 'Content-Type': 'application/json' }, '{}'];
       });
@@ -381,6 +384,6 @@ module('unit - Serialization', function (hooks) {
       await component.save();
 
       assert.deepEqual(component.changedAttributes(), {});
-    })
+    });
   });
 });


### PR DESCRIPTION
When trying to upgrade to the latest version of ember-data-model-fragments I realised there was an issue inside the `changedAttributes()`. 
`changedAttributes()` is supposed to return all the dirty attributes until the record has been fully committed not just when calling the `save` method

In the test I show what we do, we use it to send only the dirty attributes 