### PR TITLE
fix: prevent You attempted to update _tracking on Tag issue on Ember-data 4.5+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,7 +178,7 @@ jobs:
       fail-fast: true
       matrix:
         ember-try-scenario:
-          [ember-lts-3.28, ember-lts-4.4, ember-classic]
+          [ember-lts-3.28, ember-lts-4.4, ember-4.6, ember-4.8, ember-classic]
         allow-failure: [false]
         include:
           - ember-try-scenario: ember-release

--- a/addon/record-data.js
+++ b/addon/record-data.js
@@ -967,12 +967,21 @@ export default class FragmentRecordData extends RecordData {
   }
 
   notifyStateChange(key) {
-    this.storeWrapper.notifyStateChange(
-      this.modelName,
-      this.id,
-      this.clientId,
-      key
-    );
+    if (key) {
+      this.storeWrapper.notifyPropertyChange(
+        this.modelName,
+        this.id,
+        this.clientId,
+        key
+      );
+    } else {
+      this.storeWrapper.notifyStateChange(
+        this.modelName,
+        this.id,
+        this.clientId,
+        key
+      );
+    }
   }
 
   /*

--- a/addon/record-data.js
+++ b/addon/record-data.js
@@ -967,7 +967,7 @@ export default class FragmentRecordData extends RecordData {
   }
 
   notifyStateChange(key) {
-    if (key) {
+    if (key && gte('ember-data', '4.5.0')) {
       this.storeWrapper.notifyPropertyChange(
         this.modelName,
         this.id,

--- a/tests/dummy/config/ember-try.js
+++ b/tests/dummy/config/ember-try.js
@@ -26,6 +26,24 @@ module.exports = async function () {
         },
       },
       {
+        name: 'ember-4.6',
+        npm: {
+          devDependencies: {
+            'ember-source': '~4.6.0',
+            'ember-data': '~4.6.0',
+          },
+        },
+      },
+      {
+        name: 'ember-4.8',
+        npm: {
+          devDependencies: {
+            'ember-source': '~4.8.0',
+            'ember-data': '~4.8.0',
+          },
+        },
+      },
+      {
         name: 'ember-release',
         npm: {
           devDependencies: {


### PR DESCRIPTION
I realised we had an issue on, that I reproduce pretty easily in my app with Ember-data 4.6. 
The RecordState is registered when we create a new Model.
For a classic native model, the RecordState will be build after all the initial value of the attributes have been set.
But with fragments it's the opposite, the RecordState is build first then the attributes are set which result in a duplicate update of the state

This produce the exact same error that you can find on this issue: https://github.com/adopted-ember-addons/ember-data-model-fragments/issues/427

My fix is based on the RecordDataDefault, I saw they are using `notifyPropertyChange` to notify an attribute has change instead of what we are doing which is using notifyStateChange to say the state of the record has changed