### PR TITLE
allow test failures for Ember 4.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,9 +178,11 @@ jobs:
       fail-fast: true
       matrix:
         ember-try-scenario:
-          [ember-lts-3.28, ember-lts-4.4, ember-4.6, ember-4.8, ember-classic]
+          [ember-lts-3.28, ember-lts-4.4, ember-4.6, ember-classic]
         allow-failure: [false]
         include:
+          - ember-try-scenario: ember-4.8
+            allow-failure: true
           - ember-try-scenario: ember-release
             allow-failure: true
           - ember-try-scenario: ember-beta


### PR DESCRIPTION
The library is not currently expected to work on Ember 4.8. See https://github.com/adopted-ember-addons/ember-data-model-fragments/issues/471