### PR TITLE
use explicit error responses in tests

### DIFF
--- a/tests/integration/save_test.js
+++ b/tests/integration/save_test.js
@@ -801,6 +801,10 @@ module('integration - Persistence', function (hooks) {
       'Lysono Maar',
     ]);
 
+    server.put('/armies/1', () => {
+      return [400, { 'Content-Type': 'application/json' }];
+    });
+
     await assert.rejects(army.save());
 
     army.rollbackAttributes();
@@ -850,6 +854,10 @@ module('integration - Persistence', function (hooks) {
     name.set('first', 'BadFirstName');
     name.set('last', 'BadLastName');
     address.set('street', 'BadStreet');
+
+    server.put('/people/1', () => {
+      return [400, { 'Content-Type': 'application/json' }];
+    });
 
     await assert.rejects(mrStark.save());
 


### PR DESCRIPTION
Previously these tests simulate an error response with pretender's catchall unhandled request:
```
Error: Pretender intercepted PUT /people/1 but no handler was defined for this type of request
    at Pretender.unhandledRequest (pretender.es.js:297:1595)
    at Pretender.handleRequest (pretender.es.js:297:263)
    at FakeRequest.send (pretender.es.js:284:496)
    at eval (pretender.es.js:264:85)
    at new Promise (<anonymous>)
    at fetch (pretender.es.js:263:1705)
    at ApplicationAdapter._fetchRequest (rest.js:943:1)
    at ApplicationAdapter.ajax (rest.js:908:1)
    at ApplicationAdapter.updateRecord (rest.js:701:1)
    at -private.js:1022:1
```

This is annoying because it trips the debugger's uncaught exception breakpoint.
