### PR TITLE
fix passing arbitrary props to `fragmentArray.createFragment`

### DIFF
--- a/addon/array/fragment.js
+++ b/addon/array/fragment.js
@@ -149,7 +149,7 @@ const FragmentArray = StatefulArray.extend({
       this.key,
       props
     );
-    const fragment = recordData._fragmentGetRecord();
+    const fragment = recordData._fragmentGetRecord(props);
     return this.pushObject(fragment);
   },
 });

--- a/tests/unit/fragment_array_property_test.js
+++ b/tests/unit/fragment_array_property_test.js
@@ -585,4 +585,17 @@ module('unit - `MF.fragmentArray` property', function (hooks) {
       );
     });
   });
+
+  test('pass arbitrary props to createFragment', async function (assert) {
+    pushPerson(1);
+
+    const person = await store.findRecord('person', 1);
+    const address = person.addresses.createFragment({
+      street: '1 Dungeon Cell',
+      extra: 123,
+    });
+
+    assert.equal(address.street, '1 Dungeon Cell', 'street is correct');
+    assert.equal(address.extra, 123, 'extra property is correct');
+  });
 });

--- a/tests/unit/fragment_property_test.js
+++ b/tests/unit/fragment_property_test.js
@@ -520,4 +520,14 @@ module('unit - `MF.fragment` property', function (hooks) {
       assert.ok(newName.isDestroying, 'the new fragment is being destroyed');
     });
   });
+
+  test('pass arbitrary props to createFragment', async function (assert) {
+    const address = store.createFragment('address', {
+      street: '1 Dungeon Cell',
+      extra: 123,
+    });
+
+    assert.equal(address.street, '1 Dungeon Cell', 'street is correct');
+    assert.equal(address.extra, 123, 'extra property is correct');
+  });
 });


### PR DESCRIPTION
When calling `createRecord` or `createFragment`, it's possible to pass arbitrary extra props which are not defined on the model. #483 broke this behavior when calling `fragmentArray.createFragment(props)`