### PR TITLE
Preserve fragment array state after the record is unloaded

### DIFF
--- a/addon/array/stateful.js
+++ b/addon/array/stateful.js
@@ -106,6 +106,14 @@ const StatefulArray = EmberObject.extend(MutableArray, Copyable, {
     return data;
   },
 
+  _getFragmentState() {
+    return this.recordData.getFragment(this.key);
+  },
+
+  _setFragmentState(array) {
+    this.recordData.setDirtyFragment(this.key, array);
+  },
+
   replace(start, deleteCount, items) {
     assert(
       'The third argument to replace needs to be an array.',
@@ -124,7 +132,7 @@ const StatefulArray = EmberObject.extend(MutableArray, Copyable, {
       deleteCount,
       ...items.map((item, i) => this._normalizeData(item, start + i))
     );
-    this.recordData.setDirtyFragment(this.key, data);
+    this._setFragmentState(data);
     this.notify();
   },
 
@@ -133,9 +141,9 @@ const StatefulArray = EmberObject.extend(MutableArray, Copyable, {
     if (this.isDestroyed || this.isDestroying || this._isUpdating) {
       return;
     }
-    const currentState = this.recordData.getFragment(this.key);
+    const currentState = this._getFragmentState();
     if (currentState == null) {
-      // detached
+      // detached; the underlying fragment array was set to null after this StatefulArray was accessed
       return;
     }
 

--- a/addon/array/stateful.js
+++ b/addon/array/stateful.js
@@ -119,6 +119,10 @@ const StatefulArray = EmberObject.extend(MutableArray, Copyable, {
       'The third argument to replace needs to be an array.',
       isArray(items)
     );
+    assert(
+      'Attempted to update the fragment array after it was destroyed',
+      !this.isDestroyed && !this.isDestroying
+    );
     if (deleteCount === 0 && items.length === 0) {
       // array is unchanged
       return;

--- a/addon/record-data.js
+++ b/addon/record-data.js
@@ -752,9 +752,9 @@ export default class FragmentRecordData extends RecordData {
 
       Object.assign(this._fragmentData, newCanonicalFragments);
       // update fragment arrays
-      changedFragmentKeys?.forEach((key) =>
-        this._fragmentArrayCache[key]?.notify()
-      );
+      changedFragmentKeys?.forEach((key) => {
+        this._fragmentArrayCache[key]?.notify();
+      });
     }
 
     const changedKeys = mergeArrays(changedAttributeKeys, changedFragmentKeys);
@@ -830,9 +830,9 @@ export default class FragmentRecordData extends RecordData {
     const changedAttributeKeys = super.didCommit(data);
 
     // update fragment arrays
-    Object.keys(newCanonicalFragments).forEach((key) =>
-      this._fragmentArrayCache[key]?.notify()
-    );
+    changedFragmentKeys.forEach((key) => {
+      this._fragmentArrayCache[key]?.notify();
+    });
 
     const changedKeys = mergeArrays(changedAttributeKeys, changedFragmentKeys);
     if (gte('ember-data', '4.5.0') && changedKeys?.length > 0) {

--- a/tests/unit/array_property_test.js
+++ b/tests/unit/array_property_test.js
@@ -230,6 +230,42 @@ module('unit - `MF.array` property', function (hooks) {
     );
   });
 
+  test('preserve fragment array when record is unloaded', async function (assert) {
+    store.push({
+      data: {
+        type: 'person',
+        id: 1,
+        attributes: {
+          titles: ['Hand of the King', 'Master of Coin'],
+        },
+      },
+    });
+
+    const person = await store.findRecord('person', 1);
+    const titles = person.titles;
+
+    assert.strictEqual(titles.length, 2);
+
+    const titleBefore = titles.objectAt(0);
+    assert.strictEqual(titleBefore, 'Hand of the King');
+
+    person.unloadRecord();
+
+    assert.strictEqual(
+      person.titles,
+      titles,
+      'StatefulArray instance is the same after unload'
+    );
+
+    const titleAfter = titles.objectAt(0);
+
+    assert.strictEqual(
+      titleAfter,
+      titleBefore,
+      'preserve array contents after unload'
+    );
+  });
+
   if (HAS_ARRAY_OBSERVERS) {
     test('supports array observers', async function (assert) {
       store.push({

--- a/tests/unit/fragment_array_property_test.js
+++ b/tests/unit/fragment_array_property_test.js
@@ -586,6 +586,38 @@ module('unit - `MF.fragmentArray` property', function (hooks) {
     });
   });
 
+  test('preserve fragment array when record is unloaded', async function (assert) {
+    pushPerson(1);
+
+    const person = await store.findRecord('person', 1);
+    const addresses = person.addresses;
+    assert.strictEqual(addresses.length, 2);
+
+    const addressBefore = addresses.objectAt(0);
+    assert.strictEqual(addressBefore.street, '1 Sky Cell');
+
+    person.unloadRecord();
+
+    assert.strictEqual(
+      person.addresses,
+      addresses,
+      'fragment array instance is the same after unload'
+    );
+
+    const addressAfter = addresses.objectAt(0);
+
+    assert.strictEqual(
+      addressAfter,
+      addressBefore,
+      'FragmentArray instance is the same after unload'
+    );
+    assert.strictEqual(
+      addressAfter.street,
+      '1 Sky Cell',
+      'preserve fragment attributes after unload'
+    );
+  });
+
   test('pass arbitrary props to createFragment', async function (assert) {
     pushPerson(1);
 

--- a/tests/unit/fragment_property_test.js
+++ b/tests/unit/fragment_property_test.js
@@ -521,6 +521,37 @@ module('unit - `MF.fragment` property', function (hooks) {
     });
   });
 
+  test('preserve fragment attributes when record is unloaded', async function (assert) {
+    store.push({
+      data: {
+        type: 'person',
+        id: 1,
+        attributes: {
+          name: {
+            first: 'Barristan',
+            last: 'Selmy',
+          },
+        },
+      },
+    });
+
+    const person = await store.findRecord('person', 1);
+    const name = person.name;
+
+    person.unloadRecord();
+
+    assert.strictEqual(
+      person.name,
+      name,
+      'Fragment instance is the same after unload'
+    );
+    assert.strictEqual(
+      name.first,
+      'Barristan',
+      'preserve fragment attributes after unload'
+    );
+  });
+
   test('pass arbitrary props to createFragment', async function (assert) {
     const address = store.createFragment('address', {
       street: '1 Dungeon Cell',


### PR DESCRIPTION
When unloading a record, ember-data's `@attr`, `@belongsTo` and `@hasMany` preserve the record's most recent state, even though the underlying `RecordData` has been reset.

This project's `@fragment` and `@array` also work this way, but there's a problem with `@fragmentArray`.

### Reproduction

Consider this component using the [order](https://github.com/adopted-ember-addons/ember-data-model-fragments/blob/master/tests/dummy/app/models/order.js) and [product](https://github.com/adopted-ember-addons/ember-data-model-fragments/blob/master/tests/dummy/app/models/product.js) models from this project's test suite:
```gjs
import Component from '@glimmer/component';
import { service } from '@ember/service';
import { action } from '@ember/object';

export default class OrderComponent extends Component {
  @service router;

  @action async delete(order) {
    await order.destroyRecord();
    this.router.transitionTo('/orders');
  }

  <template>
    <ul>
      {{#each @order.products as |product|}}
        <li>{{product.name}}: {{product.price}}</li>
      {{/each}}
    </ul>
    
    <button type="button" {{on "click" (fn this.delete @order)}}>
      Delete
    </button>
  </template>
}
```

The products will initially render
```html
<ul>
    <li>The Strangler: 299.99</li>
    <li>Tears of Lys: 499.99</li>
</ul>
```
Clicking the delete button calls `destroyRecord` which does a delete + save, then unloads the record and all its fragments. Both products are unloaded.

But we haven't transitioned away yet; we're still rendering `order.products`. When the UI re-renders, the products no longer exist so the `FragmentArray` will *create two new products*, each in an empty state (all properties `undefined`). For a brief moment before transitioning away, the products will render as
```html
<ul>
    <li>:</li>
    <li>:</li>
</ul>
```

### Problem

In that scenario, we've done unnecessary re-rendering, displayed visual artifacts to the user, and created some unused fragment records (a possible memory leak). In practice it causes all kinds of errors in my app, because model classes have other logic which doesn't anticipate the model being created with no properties.

The problem is that `FragmentArray` stores a `currentState: RecordData[]` and expects ember-data to produce the `Fragment` record on demand from its cache each time `objectAt` is called:
https://github.com/adopted-ember-addons/ember-data-model-fragments/blob/316e9be882baf3a9b20b8d6243de3e9fb518beb0/addon/array/fragment.js#L31-L37
https://github.com/adopted-ember-addons/ember-data-model-fragments/blob/316e9be882baf3a9b20b8d6243de3e9fb518beb0/addon/record-data.js#L1001-L1009

When the records are unloaded, they're removed from ember-data's cache, then `FragmentArray` recreates them the next time they're accessed.

### Solution

My solution is for `FragmentArray` to store `currentState: Fragment[]` instead. When the `FragmentArray` is destroyed, it will stop retrieving state from its `RecordData`, effectively becoming a read-only snapshot of the latest state.
