### PR TITLE
Add new versions of ember-source to test matrix and compat.

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "webpack": "^5.75.0"
   },
   "peerDependencies": {
-    "ember-source": "^3.28.0 || ^4.0.0"
+    "ember-source": "^3.28.0 || ^4.0.0 || ^5.0.0"
   },
   "engines": {
     "node": "14.* || 16.* || >= 18"

--- a/tests/dummy/config/ember-try.js
+++ b/tests/dummy/config/ember-try.js
@@ -44,6 +44,33 @@ module.exports = async function () {
         },
       },
       {
+        name: 'ember-data-4.8-ember-4.12',
+        npm: {
+          devDependencies: {
+            'ember-source': '~4.12.0',
+            'ember-data': '~4.6.6',
+          },
+        },
+      },
+      {
+        name: 'ember-data-4.8-ember-5.4',
+        npm: {
+          devDependencies: {
+            'ember-source': '~5.4.0',
+            'ember-data': '~4.6.6',
+          },
+        },
+      },
+      {
+        name: 'ember-data-4.8-ember-5.12',
+        npm: {
+          devDependencies: {
+            'ember-source': '~5.12.0',
+            'ember-data': '~4.6.6',
+          },
+        },
+      },
+      {
         name: 'ember-release',
         npm: {
           devDependencies: {


### PR DESCRIPTION
Fixes #489.

Discussion states edmf has been compatible with most ember-source 5.x versions

from @dwickern 
> I can confirm it works. I was able to upgrade Ember 4.12 to 5.12 quite easily.
> 
> On Ember 5.6.0-5.9.2 I hit this error in dev mode https://github.com/emberjs/ember.js/blob/v5.6.0/packages/%40ember/test/index.ts#L11, called from https://github.com/emberjs/data/blob/v4.6.5/packages/store/addon/-private/backburner.js#L20. Skipping those versions, it worked again on 5.10-5.12.
> 
> So I'm currently on
> 
> * ember 5.12.0
> * ember-data 4.6.5
> * ember-data-model-fragments 6.0.10
> * ember-cli 6.2.1

If it makes sense, we can explicitly exclude versions 5.6.0-5.9.2.