### PR TITLE
Guard fragment access on destroyed/unloaded records

### DIFF
--- a/addon/attributes/array.js
+++ b/addon/attributes/array.js
@@ -55,6 +55,9 @@ export default function array(type, options) {
   // eslint-disable-next-line ember/require-computed-property-dependencies
   return computed({
     get(key) {
+      if (this.isDestroying || this.isDestroyed) {
+        return null;
+      }
       const identifier = recordIdentifierFor(this);
       const cache = this.store.cache;
       if (cache.getFragment(identifier, key) === null) {

--- a/addon/attributes/fragment-array.js
+++ b/addon/attributes/fragment-array.js
@@ -64,6 +64,9 @@ export default function fragmentArray(type, options) {
   // eslint-disable-next-line ember/require-computed-property-dependencies
   return computed({
     get(key) {
+      if (this.isDestroying || this.isDestroyed) {
+        return null;
+      }
       const identifier = recordIdentifierFor(this);
       const cache = this.store.cache;
       if (cache.getFragment(identifier, key) === null) {

--- a/addon/attributes/fragment-owner.js
+++ b/addon/attributes/fragment-owner.js
@@ -32,6 +32,7 @@ export default function fragmentOwner() {
   // setFragmentOwner(). Omitting dependent keys also avoids Ember's
   // "Attempted to access the computed ... on a destroyed object" assertion
   // when a fragment is torn down.
+  // eslint-disable-next-line ember/require-computed-property-dependencies
   return computed(function () {
     if (isDestroying(this) || isDestroyed(this)) {
       return null;

--- a/addon/attributes/fragment-owner.js
+++ b/addon/attributes/fragment-owner.js
@@ -1,5 +1,6 @@
 import { assert } from '@ember/debug';
 import { computed } from '@ember/object';
+import { isDestroying, isDestroyed } from '@ember/destroyable';
 import { isFragment } from '../fragment';
 import { recordIdentifierFor } from '@ember-data/store';
 
@@ -27,7 +28,14 @@ import { recordIdentifierFor } from '@ember-data/store';
  @return {Attribute}
  */
 export default function fragmentOwner() {
-  return computed('store.{_instanceCache,cache}', function () {
+  // No dependent keys: the value is invalidated via notifyPropertyChange in
+  // setFragmentOwner(). Omitting dependent keys also avoids Ember's
+  // "Attempted to access the computed ... on a destroyed object" assertion
+  // when a fragment is torn down.
+  return computed(function () {
+    if (isDestroying(this) || isDestroyed(this)) {
+      return null;
+    }
     assert(
       'Fragment owner properties can only be used on fragments.',
       isFragment(this),

--- a/addon/attributes/fragment.js
+++ b/addon/attributes/fragment.js
@@ -60,6 +60,7 @@ export default function fragment(type, options) {
     options,
   };
 
+  // eslint-disable-next-line ember/require-computed-property-dependencies -- isDestroying/isDestroyed are guards, not dependencies
   return computed('store.{_instanceCache,cache}', {
     get(key) {
       if (this.isDestroying || this.isDestroyed) {

--- a/addon/attributes/fragment.js
+++ b/addon/attributes/fragment.js
@@ -62,6 +62,9 @@ export default function fragment(type, options) {
 
   return computed('store.{_instanceCache,cache}', {
     get(key) {
+      if (this.isDestroying || this.isDestroyed) {
+        return null;
+      }
       const identifier = recordIdentifierFor(this);
       const cache = this.store.cache;
       const fragmentIdentifier = cache.getFragment(identifier, key);

--- a/addon/fragment.js
+++ b/addon/fragment.js
@@ -1,5 +1,6 @@
 import { get, computed } from '@ember/object';
 import Ember from 'ember';
+import { isDestroying, isDestroyed } from '@ember/destroyable';
 // DS.Model gets munged to add fragment support, which must be included first
 import { Model } from './ext';
 import { copy } from './util/copy';
@@ -115,6 +116,9 @@ const Fragment = Model.extend(Ember.Comparable, {
   },
 
   toStringExtension() {
+    if (isDestroying(this) || isDestroyed(this)) {
+      return '';
+    }
     const identifier = recordIdentifierFor(this);
     const owner = this.store.cache.getFragmentOwner(identifier);
     return owner ? `owner(${owner.ownerIdentifier?.id})` : '';
@@ -125,6 +129,9 @@ const Fragment = Model.extend(Ember.Comparable, {
     ember-data 4.12+ doesn't call toStringExtension in Model.toString().
   */
   toString() {
+    if (isDestroying(this) || isDestroyed(this)) {
+      return `<fragment(destroyed)>`;
+    }
     const identifier = recordIdentifierFor(this);
     const extension = this.toStringExtension();
     const extensionStr = extension ? `:${extension}` : '';

--- a/package.json
+++ b/package.json
@@ -120,6 +120,5 @@
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"
-  },
-  "packageManager": "pnpm@10.25.0+sha512.5e82639027af37cf832061bcc6d639c219634488e0f2baebe785028a793de7b525ffcd3f7ff574f5e9860654e098fe852ba8ac5dd5cefe1767d23a020a92f501"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -120,5 +120,6 @@
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"
-  }
+  },
+  "packageManager": "pnpm@10.25.0+sha512.5e82639027af37cf832061bcc6d639c219634488e0f2baebe785028a793de7b525ffcd3f7ff574f5e9860654e098fe852ba8ac5dd5cefe1767d23a020a92f501"
 }

--- a/tests/unit/fragment-property-test.js
+++ b/tests/unit/fragment-property-test.js
@@ -558,6 +558,78 @@ module('unit - `MF.fragment` property', function (hooks) {
     });
   });
 
+  test('accessing a fragment property on a destroyed record returns null', async function (assert) {
+    store.push({
+      data: {
+        type: 'person',
+        id: 1,
+        attributes: {
+          name: { first: 'Eddard', last: 'Stark' },
+        },
+      },
+    });
+
+    const person = store.peekRecord('person', 1);
+    const name = person.name;
+    assert.equal(name.first, 'Eddard', 'fragment is accessible before unload');
+
+    person.unloadRecord();
+
+    // Access the fragment during the destroy phase - this previously caused
+    // "recordIdentifierFor is not a record instantiated by @ember-data/store"
+    // and an infinite recursion in Fragment.toString()
+    schedule('destroy', () => {
+      assert.ok(
+        name.isDestroying,
+        'fragment is destroying after owner is unloaded',
+      );
+      // toString should not cause infinite recursion on destroyed fragment
+      assert.strictEqual(
+        name.toString(),
+        '<fragment(destroyed)>',
+        'toString returns safe string on destroyed fragment',
+      );
+    });
+  });
+
+  test('accessing a fragmentArray property on a destroyed record does not crash', async function (assert) {
+    store.push({
+      data: {
+        type: 'person',
+        id: 1,
+        attributes: {
+          names: [
+            { first: 'Eddard', last: 'Stark' },
+            { first: 'Ned', last: 'Stark' },
+          ],
+        },
+      },
+    });
+
+    const person = store.peekRecord('person', 1);
+    const names = person.names;
+    assert.equal(names.length, 2, 'fragmentArray is accessible before unload');
+
+    person.unloadRecord();
+
+    schedule('destroy', () => {
+      const firstFragment = names.objectAt(0);
+      if (firstFragment) {
+        assert.ok(
+          firstFragment.isDestroying,
+          'fragment in array is destroying after owner is unloaded',
+        );
+        assert.strictEqual(
+          firstFragment.toString(),
+          '<fragment(destroyed)>',
+          'toString returns safe string on destroyed fragment in array',
+        );
+      } else {
+        assert.ok(true, 'fragment array contents are already cleaned up');
+      }
+    });
+  });
+
   test('pass arbitrary props to createFragment', async function (assert) {
     const address = store.createFragment('address', {
       street: '1 Dungeon Cell',


### PR DESCRIPTION
Prevent crashes and infinite recursion when fragment properties are accessed on destroyed or unloaded owner records.

- Guard Fragment.toString() and toStringExtension() against destroyed fragments to break the infinite recursion cycle where recordIdentifierFor -> assertion -> String(record) -> toString() loops
- Guard fragment, fragmentArray, and array attribute getters to return null when the owner record is destroying/destroyed
- Remove dependent keys from fragmentOwner() CP and add a destroyed guard, preventing Ember's 'Attempted to access computed on a destroyed object' assertion during teardown
- Add tests verifying toString() returns a safe string on destroyed fragments without crashing