### PR TITLE
Import Comparable directly in fragments

### DIFF
--- a/addon/fragment.js
+++ b/addon/fragment.js
@@ -1,6 +1,6 @@
 import { get, computed } from '@ember/object';
-import Ember from 'ember';
 import { isDestroying, isDestroyed } from '@ember/destroyable';
+import { Comparable } from '@ember/-internals/runtime';
 // DS.Model gets munged to add fragment support, which must be included first
 import { Model } from './ext';
 import { copy } from './util/copy';
@@ -74,10 +74,10 @@ export function fragmentRecordDataFor(fragment) {
   @class Fragment
   @namespace MF
   @extends CoreModel
-  @uses Ember.Comparable
+  @uses Comparable
   @uses Copyable
 */
-const Fragment = Model.extend(Ember.Comparable, {
+const Fragment = Model.extend(Comparable, {
   /**
     Compare two fragments by identity to allow `FragmentArray` to diff arrays.
 

--- a/tests/unit/fragment-test.js
+++ b/tests/unit/fragment-test.js
@@ -1,5 +1,5 @@
 import { all } from 'rsvp';
-import Ember from 'ember';
+import { Comparable } from '@ember/-internals/runtime';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from '../helpers';
 import Pretender from 'pretender';
@@ -73,10 +73,10 @@ module('unit - `MF.Fragment`', function (hooks) {
     assert.ok(copy.last, 'Snow');
   });
 
-  test('fragments are `Ember.Comparable`', function (assert) {
+  test('fragments are `Comparable`', function (assert) {
     const fragment = store.createFragment('name');
 
-    assert.ok(Ember.Comparable.detect(fragment), 'fragments are comparable');
+    assert.ok(Comparable.detect(fragment), 'fragments are comparable');
   });
 
   test('fragments support toString', function (assert) {


### PR DESCRIPTION
## Summary
- replace `Ember.Comparable` usage with a direct `Comparable` import in fragment code and tests
- align with modern Ember imports without changing fragment behavior
- peel off a small compatibility cleanup from the larger `ember-data-5` branch