### PR TITLE
Fix createRecord crash when initializing fragment attrs with fragment instances

### DIFF
--- a/addon/cache/fragment-cache.js
+++ b/addon/cache/fragment-cache.js
@@ -382,9 +382,18 @@ export default class FragmentCache {
         .getSchemaDefinitionService()
         .attributesDefinitionFor(identifier);
 
+      // Raw fragment data (plain objects / arrays of plain objects) flows
+      // through pushFragmentData -> behavior.pushData which only accepts raw
+      // canonical data. Fragment-instance values must be adopted directly
+      // (mirroring behavior.getDefaultValue's handling of fragment defaults)
+      // so that consumers can pass `store.createFragment(...)` results into
+      // `store.createRecord(type, { fragmentKey: fragment })` without hitting
+      // "Fragment canonical value must be an object or null".
       const fragmentData = {};
+      const fragmentInstanceData = {};
       const regularOptions = {};
       let hasFragmentData = false;
+      let hasFragmentInstanceData = false;
 
       for (const [key, value] of Object.entries(options)) {
         const definition = definitions[key];
@@ -392,8 +401,13 @@ export default class FragmentCache {
           definition?.isFragment || definition?.options?.isFragment;
 
         if (isFragmentAttr && value !== undefined) {
-          fragmentData[key] = value;
-          hasFragmentData = true;
+          if (this.__fragmentState.valueContainsFragmentInstance(value)) {
+            fragmentInstanceData[key] = value;
+            hasFragmentInstanceData = true;
+          } else {
+            fragmentData[key] = value;
+            hasFragmentData = true;
+          }
         } else {
           regularOptions[key] = value;
         }
@@ -406,7 +420,35 @@ export default class FragmentCache {
         regularOptions,
       );
 
-      // Push fragment data to our fragment state manager AFTER the cache entry exists
+      // Adopt fragment-instance values directly into the canonical fragment
+      // data map. This sets up ownership on each adopted fragment and avoids
+      // the raw-object-only pushData assertion path.
+      if (hasFragmentInstanceData) {
+        for (const [key, value] of Object.entries(fragmentInstanceData)) {
+          const adopted = this.__fragmentState.adoptFragmentForKey(
+            identifier,
+            key,
+            value,
+          );
+          if (adopted !== undefined) {
+            this.__fragmentState.setCanonicalFragmentValue(
+              identifier,
+              key,
+              adopted,
+            );
+          } else {
+            // Defensive fallback: shouldn't happen because
+            // _valueContainsFragmentInstance only flagged values that
+            // adoptFragmentForKey can handle, but if it ever does, route
+            // through the raw-object path as a last resort.
+            fragmentData[key] = value;
+            hasFragmentData = true;
+          }
+        }
+      }
+
+      // Push remaining raw fragment data (plain objects) through the normal
+      // canonical-data path.
       if (hasFragmentData) {
         this.__fragmentState.pushFragmentData(
           identifier,

--- a/addon/cache/fragment-state-manager.js
+++ b/addon/cache/fragment-state-manager.js
@@ -678,6 +678,119 @@ export default class FragmentStateManager {
     });
   }
 
+  /**
+   * Returns true if the given attribute value is, or contains, an instantiated
+   * Fragment. Used by FragmentCache.clientDidCreate to route fragment-instance
+   * initialization (from `store.createRecord(type, { key: fragmentInstance })`)
+   * through the adopt-fragment path instead of pushFragmentData (which only
+   * accepts raw object/null canonical data).
+   */
+  valueContainsFragmentInstance(value) {
+    if (value == null) {
+      return false;
+    }
+    if (isFragment(value)) {
+      return true;
+    }
+    if (isArray(value)) {
+      return value.some((item) => isFragment(item));
+    }
+    return false;
+  }
+
+  /**
+   * Adopt an existing fragment instance (or array of fragment instances) for the
+   * given owner identifier + key. This is used by the client-created path
+   * (`createRecord(...props)`) when consumers pass already-instantiated
+   * fragments rather than raw object data.
+   *
+   * Returns the canonical fragment identifier value to be stored in the
+   * fragment data map (a single identifier for `fragment` kind, an array of
+   * identifiers for `fragment-array` kind).
+   *
+   * Asserts when the provided value does not match the fragment kind/type
+   * declared on the owner's schema.
+   */
+  adoptFragmentForKey(ownerIdentifier, key, value) {
+    const behaviors = this._getBehaviors(ownerIdentifier);
+    const behavior = behaviors[key];
+    assert(
+      `Attribute '${key}' for model '${ownerIdentifier.type}' must be a fragment`,
+      behavior != null,
+    );
+
+    const definition = behavior.definition;
+    const isArrayBehavior = behavior instanceof FragmentArrayBehavior;
+    const isSingleFragmentBehavior = behavior instanceof FragmentBehavior;
+
+    // Only single-fragment and fragment-array behaviors support adopting
+    // fragment instances. Plain array behavior should never receive a
+    // fragment instance.
+    if (!isSingleFragmentBehavior && !isArrayBehavior) {
+      return undefined;
+    }
+
+    if (isSingleFragmentBehavior) {
+      if (value === null) {
+        return null;
+      }
+      if (!isFragment(value)) {
+        return undefined;
+      }
+      assert(
+        `The value provided for fragment attribute '${key}' must be a '${definition.modelName}' fragment`,
+        isInstanceOfType(
+          this.__storeWrapper._store.modelFor(definition.modelName),
+          value,
+        ),
+      );
+      const fragmentIdentifier = this._identifierFor(value);
+      this.setFragmentOwner(fragmentIdentifier, ownerIdentifier, key);
+      return fragmentIdentifier;
+    }
+
+    // fragment-array behavior
+    if (value === null) {
+      return null;
+    }
+    if (!isArray(value)) {
+      return undefined;
+    }
+    // Only treat the value as fragment-instance input if at least one entry is
+    // a fragment instance. Otherwise let the regular pushData path handle it
+    // (raw object array).
+    if (!value.some((item) => isFragment(item))) {
+      return undefined;
+    }
+    return value.map((item) => {
+      if (isFragment(item)) {
+        assert(
+          `The value provided for fragment array attribute '${key}' can only include '${definition.modelName}' fragments`,
+          isInstanceOfType(
+            this.__storeWrapper._store.modelFor(definition.modelName),
+            item,
+          ),
+        );
+        const fragmentIdentifier = this._identifierFor(item);
+        this.setFragmentOwner(fragmentIdentifier, ownerIdentifier, key);
+        return fragmentIdentifier;
+      }
+      // Raw object entry mixed in with fragments - create a new fragment for it.
+      return this._newFragmentIdentifier(ownerIdentifier, definition, item);
+    });
+  }
+
+  /**
+   * Set canonical fragment data for a key on an owner identifier. Used by the
+   * client-created path after adopting fragment instances so subsequent
+   * getFragment/getCurrentState calls find the canonical value without going
+   * through pushData (which only accepts raw object/null canonical data).
+   */
+  setCanonicalFragmentValue(identifier, key, value) {
+    const fragmentData = this._getFragmentDataMap(identifier);
+    fragmentData[key] = value;
+  }
+
   _newFragmentIdentifierForKey(identifier, key, attributes) {
     const behaviors = this._getBehaviors(identifier);
     const behavior = behaviors[key];

--- a/tests/unit/cache-test.js
+++ b/tests/unit/cache-test.js
@@ -682,6 +682,142 @@ module('unit - Fragment Owner Tracking', function (hooks) {
       'fragmentOwner returns owner record',
     );
   });
+
+  test('createRecord accepts an existing fragment instance for a single fragment attr', async function (assert) {
+    const name = store.createFragment('name', {
+      first: 'Arya',
+      last: 'Stark',
+    });
+
+    let person;
+    try {
+      person = store.createRecord('person', { name });
+    } catch (e) {
+      assert.notOk(
+        true,
+        `createRecord with fragment instance threw: ${e.message}`,
+      );
+      return;
+    }
+
+    assert.ok(person, 'person was created without error');
+    assert.strictEqual(
+      person.name.first,
+      'Arya',
+      'fragment data is preserved (first)',
+    );
+    assert.strictEqual(
+      person.name.last,
+      'Stark',
+      'fragment data is preserved (last)',
+    );
+
+    // Prefer adoption (no duplication) over re-creating a fragment.
+    assert.strictEqual(
+      person.name,
+      name,
+      'createRecord adopts the provided fragment instance instead of duplicating it',
+    );
+
+    const fragmentIdentifier = recordIdentifierFor(name);
+    const ownerInfo = store.cache.getFragmentOwner(fragmentIdentifier);
+    assert.ok(ownerInfo, 'adopted fragment has an owner');
+    assert.strictEqual(
+      ownerInfo.key,
+      'name',
+      'adopted fragment is owned at the correct key',
+    );
+    assert.strictEqual(
+      ownerInfo.ownerIdentifier,
+      recordIdentifierFor(person),
+      'adopted fragment is owned by the new record',
+    );
+  });
+
+  test('createRecord accepts existing fragment instances for a fragment-array attr', async function (assert) {
+    const name1 = store.createFragment('name', {
+      first: 'Arya',
+      last: 'Stark',
+    });
+    const name2 = store.createFragment('name', {
+      first: 'Sansa',
+      last: 'Stark',
+    });
+
+    let person;
+    try {
+      person = store.createRecord('person', { names: [name1, name2] });
+    } catch (e) {
+      assert.notOk(
+        true,
+        `createRecord with fragment-array instances threw: ${e.message}`,
+      );
+      return;
+    }
+
+    assert.ok(person, 'person was created without error');
+    assert.strictEqual(person.names.length, 2, 'fragment array has 2 entries');
+    assert.strictEqual(
+      person.names.objectAt(0),
+      name1,
+      'first fragment is adopted (not duplicated)',
+    );
+    assert.strictEqual(
+      person.names.objectAt(1),
+      name2,
+      'second fragment is adopted (not duplicated)',
+    );
+    assert.strictEqual(
+      person.names.objectAt(0).first,
+      'Arya',
+      'first fragment data preserved',
+    );
+    assert.strictEqual(
+      person.names.objectAt(1).first,
+      'Sansa',
+      'second fragment data preserved',
+    );
+
+    const personIdentifier = recordIdentifierFor(person);
+    [name1, name2].forEach((fragment) => {
+      const ownerInfo = store.cache.getFragmentOwner(
+        recordIdentifierFor(fragment),
+      );
+      assert.ok(ownerInfo, 'adopted fragment has an owner');
+      assert.strictEqual(
+        ownerInfo.ownerIdentifier,
+        personIdentifier,
+        'adopted fragment owner is the new record',
+      );
+      assert.strictEqual(
+        ownerInfo.key,
+        'names',
+        'adopted fragment owner key is correct',
+      );
+    });
+  });
+
+  test('createRecord still accepts plain object literals for fragment attrs (no regression)', async function (assert) {
+    const person = store.createRecord('person', {
+      name: { first: 'Arya', last: 'Stark' },
+    });
+
+    assert.ok(person, 'person was created');
+    assert.ok(person.name instanceof MF.Fragment, 'fragment was instantiated');
+    assert.strictEqual(person.name.first, 'Arya', 'first preserved');
+    assert.strictEqual(person.name.last, 'Stark', 'last preserved');
+  });
+
+  test('createRecord asserts when given a fragment instance of the wrong type', async function (assert) {
+    // 'address' is a different fragment model than the one declared on `name`.
+    const wrong = store.createFragment('address', {
+      street: '1 Winterfell Way',
+    });
+
+    assert.expectAssertion(() => {
+      store.createRecord('person', { name: wrong });
+    }, "The value provided for fragment attribute 'name' must be a 'name' fragment");
+  });
 });
 
 module('unit - Fragment Edge Cases', function (hooks) {


### PR DESCRIPTION
## Summary

- Fix `Fragment canonical value must be an object or null` assertion when consumers pass fragment instances into `store.createRecord`, e.g. `store.createRecord('person', { name: store.createFragment('name', {...}) })`.
- The V2 cache's `clientDidCreate` was forwarding fragment-instance values into `pushFragmentData` → `FragmentBehavior.pushData` / `FragmentArrayBehavior.pushData`, which only accept raw object/null canonical data. This was inconsistent with `getDefaultValue`, which already supports fragment instances.
- `clientDidCreate` now adopts fragment instances directly (asserting type, assigning owner) and only routes plain object/null values through the raw-canonical `pushData` path. Server canonical semantics (`put`, `upsert`, `didCommit`) are unchanged.

## Changes

- `addon/cache/fragment-state-manager.js`: add `valueContainsFragmentInstance`, `adoptFragmentForKey`, and `setCanonicalFragmentValue` helpers. `adoptFragmentForKey` mirrors the fragment-instance branch of `FragmentBehavior.getDefaultValue` / `FragmentArrayBehavior.getDefaultValue` — it asserts the provided fragment matches the schema's declared `modelName`, resolves its identifier, and calls `setFragmentOwner`.
- `addon/cache/fragment-cache.js`: in `clientDidCreate`, split fragment-attribute init values into "fragment instance" vs "raw object" buckets and route each through the appropriate path. Mixed fragment-array values (instances + plain objects) are supported. Adopted fragments are not duplicated.

## Tests

Added regression tests in `tests/unit/cache-test.js`:

1. Single fragment attr initialized from a fragment instance — no error, data preserved, fragment adopted (not duplicated), owner correctly assigned.
2. Fragment-array attr initialized from `[fragment1, fragment2]` — no error, ownership correct, both fragments adopted.
3. Existing object-literal initialization still works (no regression).
4. Asserts when a fragment instance of the wrong type is provided.

Server payload paths (`pushPayload` / `didCommit`) still expect raw canonical data — unchanged.