### PR TITLE
Fix fragmentSerialize writing to wrong location for fragment-only models

### DIFF
--- a/addon/serializers/utils.js
+++ b/addon/serializers/utils.js
@@ -1,5 +1,7 @@
 import { assert } from '@ember/debug';
 import { getOwner } from '@ember/application';
+import JSONAPISerializer from '@ember-data/serializer/json-api';
+import RESTSerializer from '@ember-data/serializer/rest';
 
 /**
  * Helper function to implement fragment transform lookup.
@@ -102,16 +104,31 @@ function isFragmentAttribute(meta) {
 }
 
 function serializedAttributesHash(serializer, snapshot, payload) {
-  if (payload?.data?.attributes) {
-    return payload.data.attributes;
+  // JSON:API: fragment attributes belong inside payload.data.attributes.
+  // If the model has no regular @attr fields, JSONAPISerializer#serialize
+  // omits `attributes` entirely, so we create it here. We dispatch by
+  // serializer type rather than payload shape, because a model could
+  // legitimately declare an @attr named `data` under RESTSerializer /
+  // JSONSerializer and we must not clobber it.
+  if (serializer instanceof JSONAPISerializer) {
+    if (payload?.data && typeof payload.data === 'object') {
+      payload.data.attributes ??= {};
+      return payload.data.attributes;
+    }
+    return payload;
   }
 
-  const rootKey = serializer.payloadKeyFromModelName?.(snapshot.modelName);
-
-  if (rootKey && payload?.[rootKey] && typeof payload[rootKey] === 'object') {
-    return payload[rootKey];
+  // RESTSerializer: payload is keyed by the model's payload key, e.g.
+  // `{ person: { ...attrs } }`.
+  if (serializer instanceof RESTSerializer) {
+    const rootKey = serializer.payloadKeyFromModelName?.(snapshot.modelName);
+    if (rootKey && payload?.[rootKey] && typeof payload[rootKey] === 'object') {
+      return payload[rootKey];
+    }
+    return payload;
   }
 
+  // JSONSerializer (default): flat hash keyed by attribute names.
   return payload;
 }
 

--- a/tests/unit/serialize-test.js
+++ b/tests/unit/serialize-test.js
@@ -1,10 +1,19 @@
 import { isEmpty } from '@ember/utils';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from '../helpers';
+import Model, { attr } from '@ember-data/model';
 import JSONSerializer from '@ember-data/serializer/json';
-import FragmentSerializer from 'ember-data-model-fragments/serializer';
+import FragmentSerializer, {
+  FragmentJSONAPISerializer,
+  FragmentRESTSerializer,
+} from 'ember-data-model-fragments/serializer';
+import Fragment from 'ember-data-model-fragments/fragment';
 import Person from 'dummy/models/person';
-import { fragmentArray, array } from 'ember-data-model-fragments/attributes';
+import {
+  fragment,
+  fragmentArray,
+  array,
+} from 'ember-data-model-fragments/attributes';
 import Pretender from 'pretender';
 // eslint-disable-next-line ember/use-ember-data-rfc-395-imports
 import DS from 'ember-data';
@@ -401,6 +410,171 @@ module('unit - Serialization', function (hooks) {
       'boolean values are serialized',
     );
   });
+
+  module(
+    'models with only fragment attributes (no @attr fields)',
+    function () {
+      // Models that have only fragment attributes exposed JSON:API serializers
+      // omitting `data.attributes` from the serialized payload. The
+      // fragmentSerialize helper must still place fragment values inside
+      // `data.attributes` rather than at the top level alongside `data`.
+
+      class Timestamps extends Fragment {
+        @attr('string') createdAt;
+        @attr('string') updatedAt;
+      }
+
+      class FragmentOnly extends Model {
+        @fragment('timestamps') timestamps;
+      }
+
+      function registerFragmentOnly() {
+        owner.register('model:timestamps', Timestamps);
+        owner.register('model:fragment-only', FragmentOnly);
+      }
+
+      test('FragmentJSONAPISerializer writes fragments inside data.attributes', async function (assert) {
+        registerFragmentOnly();
+        owner.register('serializer:fragment-only', FragmentJSONAPISerializer);
+
+        store.push({
+          data: {
+            type: 'fragment-only',
+            id: '1',
+            attributes: {
+              timestamps: { createdAt: 'a', updatedAt: 'b' },
+            },
+          },
+        });
+
+        const record = store.peekRecord('fragment-only', '1');
+        const serialized = record.serialize();
+
+        assert.ok(
+          serialized.data && typeof serialized.data === 'object',
+          'payload has data',
+        );
+        assert.ok(
+          serialized.data.attributes &&
+            typeof serialized.data.attributes === 'object',
+          'data.attributes was created even when no @attr fields exist',
+        );
+        assert.deepEqual(
+          serialized.data.attributes.timestamps,
+          { createdAt: 'a', updatedAt: 'b' },
+          'fragment is written under data.attributes',
+        );
+        assert.notOk(
+          'timestamps' in serialized,
+          'fragment is NOT written at the top level alongside data',
+        );
+      });
+
+      test('FragmentRESTSerializer writes fragments under the model root key', async function (assert) {
+        registerFragmentOnly();
+        owner.register('serializer:fragment-only', FragmentRESTSerializer);
+
+        store.push({
+          data: {
+            type: 'fragment-only',
+            id: '1',
+            attributes: {
+              timestamps: { createdAt: 'a', updatedAt: 'b' },
+            },
+          },
+        });
+
+        const record = store.peekRecord('fragment-only', '1');
+        const serialized = record.serialize();
+
+        assert.deepEqual(
+          serialized.timestamps,
+          { createdAt: 'a', updatedAt: 'b' },
+          'fragment is included in the serialized REST payload',
+        );
+      });
+
+      test('FragmentSerializer (JSONSerializer) writes fragments at the root', async function (assert) {
+        registerFragmentOnly();
+        owner.register('serializer:fragment-only', FragmentSerializer);
+
+        store.push({
+          data: {
+            type: 'fragment-only',
+            id: '1',
+            attributes: {
+              timestamps: { createdAt: 'a', updatedAt: 'b' },
+            },
+          },
+        });
+
+        const record = store.peekRecord('fragment-only', '1');
+        const serialized = record.serialize();
+
+        assert.deepEqual(
+          serialized.timestamps,
+          { createdAt: 'a', updatedAt: 'b' },
+          'fragment is included in the serialized JSON payload',
+        );
+      });
+
+      test('REST/JSON serializers do not treat a top-level `data` @attr as a JSON:API envelope', async function (assert) {
+        // Regression: the JSON:API attribute-hash logic must not be triggered
+        // by a model that legitimately declares an @attr named `data`.
+        class WithDataAttr extends Model {
+          @attr('string') name;
+          @attr() data;
+          @fragment('timestamps') timestamps;
+        }
+        owner.register('model:timestamps', Timestamps);
+        owner.register('model:with-data-attr', WithDataAttr);
+
+        store.push({
+          data: {
+            type: 'with-data-attr',
+            id: '1',
+            attributes: {
+              name: 'thing',
+              data: { user: 'value', nested: { foo: 1 } },
+              timestamps: { createdAt: 'a', updatedAt: 'b' },
+            },
+          },
+        });
+
+        const record = store.peekRecord('with-data-attr', '1');
+
+        owner.register('serializer:with-data-attr', FragmentSerializer);
+        const jsonSerialized = record.serialize();
+        assert.deepEqual(
+          jsonSerialized.data,
+          { user: 'value', nested: { foo: 1 } },
+          'JSONSerializer leaves user `data` attr untouched',
+        );
+        assert.notOk(
+          jsonSerialized.data.attributes,
+          'no spurious `attributes` key injected into user `data`',
+        );
+        assert.deepEqual(
+          jsonSerialized.timestamps,
+          { createdAt: 'a', updatedAt: 'b' },
+          'fragment still serialized at the root',
+        );
+
+        owner.unregister('serializer:with-data-attr');
+        owner.register('serializer:with-data-attr', FragmentRESTSerializer);
+        const restSerialized = record.serialize();
+        assert.deepEqual(
+          restSerialized.data,
+          { user: 'value', nested: { foo: 1 } },
+          'RESTSerializer leaves user `data` attr untouched',
+        );
+        assert.notOk(
+          restSerialized.data.attributes,
+          'no spurious `attributes` key injected into user `data` (REST)',
+        );
+      });
+    },
+  );
 
   module('when saving the record', function (saveHooks) {
     let server;

--- a/tests/unit/serialize-test.js
+++ b/tests/unit/serialize-test.js
@@ -411,170 +411,167 @@ module('unit - Serialization', function (hooks) {
     );
   });
 
-  module(
-    'models with only fragment attributes (no @attr fields)',
-    function () {
-      // Models that have only fragment attributes exposed JSON:API serializers
-      // omitting `data.attributes` from the serialized payload. The
-      // fragmentSerialize helper must still place fragment values inside
-      // `data.attributes` rather than at the top level alongside `data`.
+  module('models with only fragment attributes (no @attr fields)', function () {
+    // Models that have only fragment attributes exposed JSON:API serializers
+    // omitting `data.attributes` from the serialized payload. The
+    // fragmentSerialize helper must still place fragment values inside
+    // `data.attributes` rather than at the top level alongside `data`.
 
-      class Timestamps extends Fragment {
-        @attr('string') createdAt;
-        @attr('string') updatedAt;
-      }
+    class Timestamps extends Fragment {
+      @attr('string') createdAt;
+      @attr('string') updatedAt;
+    }
 
-      class FragmentOnly extends Model {
+    class FragmentOnly extends Model {
+      @fragment('timestamps') timestamps;
+    }
+
+    function registerFragmentOnly() {
+      owner.register('model:timestamps', Timestamps);
+      owner.register('model:fragment-only', FragmentOnly);
+    }
+
+    test('FragmentJSONAPISerializer writes fragments inside data.attributes', async function (assert) {
+      registerFragmentOnly();
+      owner.register('serializer:fragment-only', FragmentJSONAPISerializer);
+
+      store.push({
+        data: {
+          type: 'fragment-only',
+          id: '1',
+          attributes: {
+            timestamps: { createdAt: 'a', updatedAt: 'b' },
+          },
+        },
+      });
+
+      const record = store.peekRecord('fragment-only', '1');
+      const serialized = record.serialize();
+
+      assert.ok(
+        serialized.data && typeof serialized.data === 'object',
+        'payload has data',
+      );
+      assert.ok(
+        serialized.data.attributes &&
+          typeof serialized.data.attributes === 'object',
+        'data.attributes was created even when no @attr fields exist',
+      );
+      assert.deepEqual(
+        serialized.data.attributes.timestamps,
+        { createdAt: 'a', updatedAt: 'b' },
+        'fragment is written under data.attributes',
+      );
+      assert.notOk(
+        'timestamps' in serialized,
+        'fragment is NOT written at the top level alongside data',
+      );
+    });
+
+    test('FragmentRESTSerializer writes fragments under the model root key', async function (assert) {
+      registerFragmentOnly();
+      owner.register('serializer:fragment-only', FragmentRESTSerializer);
+
+      store.push({
+        data: {
+          type: 'fragment-only',
+          id: '1',
+          attributes: {
+            timestamps: { createdAt: 'a', updatedAt: 'b' },
+          },
+        },
+      });
+
+      const record = store.peekRecord('fragment-only', '1');
+      const serialized = record.serialize();
+
+      assert.deepEqual(
+        serialized.timestamps,
+        { createdAt: 'a', updatedAt: 'b' },
+        'fragment is included in the serialized REST payload',
+      );
+    });
+
+    test('FragmentSerializer (JSONSerializer) writes fragments at the root', async function (assert) {
+      registerFragmentOnly();
+      owner.register('serializer:fragment-only', FragmentSerializer);
+
+      store.push({
+        data: {
+          type: 'fragment-only',
+          id: '1',
+          attributes: {
+            timestamps: { createdAt: 'a', updatedAt: 'b' },
+          },
+        },
+      });
+
+      const record = store.peekRecord('fragment-only', '1');
+      const serialized = record.serialize();
+
+      assert.deepEqual(
+        serialized.timestamps,
+        { createdAt: 'a', updatedAt: 'b' },
+        'fragment is included in the serialized JSON payload',
+      );
+    });
+
+    test('REST/JSON serializers do not treat a top-level `data` @attr as a JSON:API envelope', async function (assert) {
+      // Regression: the JSON:API attribute-hash logic must not be triggered
+      // by a model that legitimately declares an @attr named `data`.
+      class WithDataAttr extends Model {
+        @attr('string') name;
+        @attr() data;
         @fragment('timestamps') timestamps;
       }
+      owner.register('model:timestamps', Timestamps);
+      owner.register('model:with-data-attr', WithDataAttr);
 
-      function registerFragmentOnly() {
-        owner.register('model:timestamps', Timestamps);
-        owner.register('model:fragment-only', FragmentOnly);
-      }
-
-      test('FragmentJSONAPISerializer writes fragments inside data.attributes', async function (assert) {
-        registerFragmentOnly();
-        owner.register('serializer:fragment-only', FragmentJSONAPISerializer);
-
-        store.push({
-          data: {
-            type: 'fragment-only',
-            id: '1',
-            attributes: {
-              timestamps: { createdAt: 'a', updatedAt: 'b' },
-            },
+      store.push({
+        data: {
+          type: 'with-data-attr',
+          id: '1',
+          attributes: {
+            name: 'thing',
+            data: { user: 'value', nested: { foo: 1 } },
+            timestamps: { createdAt: 'a', updatedAt: 'b' },
           },
-        });
-
-        const record = store.peekRecord('fragment-only', '1');
-        const serialized = record.serialize();
-
-        assert.ok(
-          serialized.data && typeof serialized.data === 'object',
-          'payload has data',
-        );
-        assert.ok(
-          serialized.data.attributes &&
-            typeof serialized.data.attributes === 'object',
-          'data.attributes was created even when no @attr fields exist',
-        );
-        assert.deepEqual(
-          serialized.data.attributes.timestamps,
-          { createdAt: 'a', updatedAt: 'b' },
-          'fragment is written under data.attributes',
-        );
-        assert.notOk(
-          'timestamps' in serialized,
-          'fragment is NOT written at the top level alongside data',
-        );
+        },
       });
 
-      test('FragmentRESTSerializer writes fragments under the model root key', async function (assert) {
-        registerFragmentOnly();
-        owner.register('serializer:fragment-only', FragmentRESTSerializer);
+      const record = store.peekRecord('with-data-attr', '1');
 
-        store.push({
-          data: {
-            type: 'fragment-only',
-            id: '1',
-            attributes: {
-              timestamps: { createdAt: 'a', updatedAt: 'b' },
-            },
-          },
-        });
+      owner.register('serializer:with-data-attr', FragmentSerializer);
+      const jsonSerialized = record.serialize();
+      assert.deepEqual(
+        jsonSerialized.data,
+        { user: 'value', nested: { foo: 1 } },
+        'JSONSerializer leaves user `data` attr untouched',
+      );
+      assert.notOk(
+        jsonSerialized.data.attributes,
+        'no spurious `attributes` key injected into user `data`',
+      );
+      assert.deepEqual(
+        jsonSerialized.timestamps,
+        { createdAt: 'a', updatedAt: 'b' },
+        'fragment still serialized at the root',
+      );
 
-        const record = store.peekRecord('fragment-only', '1');
-        const serialized = record.serialize();
-
-        assert.deepEqual(
-          serialized.timestamps,
-          { createdAt: 'a', updatedAt: 'b' },
-          'fragment is included in the serialized REST payload',
-        );
-      });
-
-      test('FragmentSerializer (JSONSerializer) writes fragments at the root', async function (assert) {
-        registerFragmentOnly();
-        owner.register('serializer:fragment-only', FragmentSerializer);
-
-        store.push({
-          data: {
-            type: 'fragment-only',
-            id: '1',
-            attributes: {
-              timestamps: { createdAt: 'a', updatedAt: 'b' },
-            },
-          },
-        });
-
-        const record = store.peekRecord('fragment-only', '1');
-        const serialized = record.serialize();
-
-        assert.deepEqual(
-          serialized.timestamps,
-          { createdAt: 'a', updatedAt: 'b' },
-          'fragment is included in the serialized JSON payload',
-        );
-      });
-
-      test('REST/JSON serializers do not treat a top-level `data` @attr as a JSON:API envelope', async function (assert) {
-        // Regression: the JSON:API attribute-hash logic must not be triggered
-        // by a model that legitimately declares an @attr named `data`.
-        class WithDataAttr extends Model {
-          @attr('string') name;
-          @attr() data;
-          @fragment('timestamps') timestamps;
-        }
-        owner.register('model:timestamps', Timestamps);
-        owner.register('model:with-data-attr', WithDataAttr);
-
-        store.push({
-          data: {
-            type: 'with-data-attr',
-            id: '1',
-            attributes: {
-              name: 'thing',
-              data: { user: 'value', nested: { foo: 1 } },
-              timestamps: { createdAt: 'a', updatedAt: 'b' },
-            },
-          },
-        });
-
-        const record = store.peekRecord('with-data-attr', '1');
-
-        owner.register('serializer:with-data-attr', FragmentSerializer);
-        const jsonSerialized = record.serialize();
-        assert.deepEqual(
-          jsonSerialized.data,
-          { user: 'value', nested: { foo: 1 } },
-          'JSONSerializer leaves user `data` attr untouched',
-        );
-        assert.notOk(
-          jsonSerialized.data.attributes,
-          'no spurious `attributes` key injected into user `data`',
-        );
-        assert.deepEqual(
-          jsonSerialized.timestamps,
-          { createdAt: 'a', updatedAt: 'b' },
-          'fragment still serialized at the root',
-        );
-
-        owner.unregister('serializer:with-data-attr');
-        owner.register('serializer:with-data-attr', FragmentRESTSerializer);
-        const restSerialized = record.serialize();
-        assert.deepEqual(
-          restSerialized.data,
-          { user: 'value', nested: { foo: 1 } },
-          'RESTSerializer leaves user `data` attr untouched',
-        );
-        assert.notOk(
-          restSerialized.data.attributes,
-          'no spurious `attributes` key injected into user `data` (REST)',
-        );
-      });
-    },
-  );
+      owner.unregister('serializer:with-data-attr');
+      owner.register('serializer:with-data-attr', FragmentRESTSerializer);
+      const restSerialized = record.serialize();
+      assert.deepEqual(
+        restSerialized.data,
+        { user: 'value', nested: { foo: 1 } },
+        'RESTSerializer leaves user `data` attr untouched',
+      );
+      assert.notOk(
+        restSerialized.data.attributes,
+        'no spurious `attributes` key injected into user `data` (REST)',
+      );
+    });
+  });
 
   module('when saving the record', function (saveHooks) {
     let server;


### PR DESCRIPTION
## Summary

When a model declares only fragment attributes (no regular `@attr` fields), `JSONAPISerializer#serialize` returns `{ data: { type } }` with no `data.attributes` object. The previous `serializedAttributesHash` fell through to returning the entire payload, so fragment values were written at the top level alongside `data`:

```js
// expected:
{ data: { type: 'foos', attributes: { timestamps: {...} } } }
// actual (before fix):
{ data: { type: 'foos' }, timestamps: {...} }
```

## Fix

In `addon/serializers/utils.js`, dispatch `serializedAttributesHash` by serializer type using `instanceof` checks on `JSONAPISerializer` / `RESTSerializer` rather than sniffing payload shape. For JSON:API, create `payload.data.attributes` if missing.

Using `instanceof` (instead of e.g. `payload.data && typeof payload.data === 'object'`) avoids a collision case: a model that legitimately declares `@attr('object') data` under REST/JSONSerializer would otherwise have its `data` attr clobbered with an injected `attributes` key.

## Tests

Added a `models with only fragment attributes (no @attr fields)` sub-module in `tests/unit/serialize-test.js` covering all three serializers:

- `FragmentJSONAPISerializer` writes fragments inside `data.attributes` (and not at the top level).
- `FragmentRESTSerializer` writes fragments under the model root key.
- `FragmentSerializer` (JSONSerializer) writes fragments at the root.
- Regression: REST/JSON serializers do **not** treat a top-level `data` `@attr` as a JSON:API envelope.

All 14 Serialization tests pass.