### PR TITLE
revert failed release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,34 +1,5 @@
 # Changelog
 
-## Release (2026-04-28)
-
-* ember-data-model-fragments 8.0.0 (major)
-
-#### :boom: Breaking Change
-* `ember-data-model-fragments`
-  * [#507](https://github.com/adopted-ember-addons/ember-data-model-fragments/pull/507) Support ember-data 4.13.x and require extending FragmentStore/FragmentSerializer ([@RobbieTheWagner](https://github.com/RobbieTheWagner))
-
-#### :rocket: Enhancement
-* `ember-data-model-fragments`
-  * [#523](https://github.com/adopted-ember-addons/ember-data-model-fragments/pull/523) Add ember-data 5.x support ([@RobbieTheWagner](https://github.com/RobbieTheWagner))
-  * [#521](https://github.com/adopted-ember-addons/ember-data-model-fragments/pull/521) Import Comparable directly in fragments ([@RobbieTheWagner](https://github.com/RobbieTheWagner))
-
-#### :bug: Bug Fix
-* `ember-data-model-fragments`
-  * [#526](https://github.com/adopted-ember-addons/ember-data-model-fragments/pull/526) Fix fragmentSerialize writing to wrong location for fragment-only models ([@RobbieTheWagner](https://github.com/RobbieTheWagner))
-  * [#525](https://github.com/adopted-ember-addons/ember-data-model-fragments/pull/525) Fix createRecord crash when initializing fragment attrs with fragment instances ([@RobbieTheWagner](https://github.com/RobbieTheWagner))
-  * [#524](https://github.com/adopted-ember-addons/ember-data-model-fragments/pull/524) Fix fragment serializer resolution falling back to application serializer ([@RobbieTheWagner](https://github.com/RobbieTheWagner))
-
-#### :house: Internal
-* `ember-data-model-fragments`
-  * [#522](https://github.com/adopted-ember-addons/ember-data-model-fragments/pull/522) Update release-plan ([@RobbieTheWagner](https://github.com/RobbieTheWagner))
-  * [#520](https://github.com/adopted-ember-addons/ember-data-model-fragments/pull/520) Remove unused legacy record-data implementation ([@RobbieTheWagner](https://github.com/RobbieTheWagner))
-  * [#519](https://github.com/adopted-ember-addons/ember-data-model-fragments/pull/519) Remove old ember-data version checks ([@RobbieTheWagner](https://github.com/RobbieTheWagner))
-  * [#517](https://github.com/adopted-ember-addons/ember-data-model-fragments/pull/517) Various tech debt cleanup ([@RobbieTheWagner](https://github.com/RobbieTheWagner))
-
-#### Committers: 1
-- Robbie Wagner ([@RobbieTheWagner](https://github.com/RobbieTheWagner))
-
 ## Release (2026-02-27)
 
 * ember-data-model-fragments 7.0.3 (patch)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-data-model-fragments",
-  "version": "8.0.0",
+  "version": "7.0.3",
   "description": "Ember Data addon to support nested JSON documents",
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
This reverts https://github.com/adopted-ember-addons/ember-data-model-fragments/pull/518 so that we don't skip a version in package.json

VERY IMORTANT NOTE: this does **NOT** change the .release-plan.json file back to what it was before that commit. We should never change that file in any PR other than a Plan Release PR. We don't need to worry about it having the wrong versions on main because it's a transient file and it will be re-created properly once this PR is merged 👍 

